### PR TITLE
feat: add paragraph spacing and zoom settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -291,7 +291,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -898,7 +897,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -922,7 +920,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2827,7 +2824,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.12.1.tgz",
       "integrity": "sha512-dn5uTnsTUjMze26iRhcus8+2auW9+/vOpk6suXg/lhBp+UzOM+EALKE3S5086ANJNgBh1PDHoBX+r1T7wEmheg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -2893,7 +2889,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.12.1.tgz",
       "integrity": "sha512-hlLOWQmSDgPWzHujR1wPK82P83C3QcDiVKkjIkCsItwnKK8endJUtdvWDJji4ZJzFKHl8kr6eGzPJJ5/4Es0ew==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -3047,7 +3042,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.12.1.tgz",
       "integrity": "sha512-v3WC9TR8QRVwmubuKjUplAXeTzTq2hiVKGHBbW15LTqqfsEJwt1YHUl/Sc+pSAeJfY7th5wheNfZFCsCBCW3qg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -3167,7 +3161,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.12.1.tgz",
       "integrity": "sha512-Xtg2Ot3oebg6+ponJ3yp8VcxPtdaHaub62Eoh8DKvBexyfqp+lMDtOpJZXA9NImVG3gKn+5EAIq8kx5AtrVlJQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -3199,7 +3192,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.12.1.tgz",
       "integrity": "sha512-YGv8uZrTraXzB3DPQYsyIB90Girx5QZdZOBSDj0R2bWSXc2Huqdb9PaulXqDQjEv/dp9x6w6+Q2VNIagCPUQwA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -3593,7 +3585,6 @@
       "integrity": "sha512-PC0PDZfJg8sP7cmKe6L3QIL8GZwU5aRvUFedqSIpw3B+QjRSUZeeITC2M5XKeMXEzL6wccN196iy3JLwKNvDVA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.1",
         "@typescript-eslint/types": "8.48.1",
@@ -4069,7 +4060,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4467,7 +4457,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -5002,7 +4991,6 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -5385,7 +5373,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6069,7 +6056,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6130,7 +6116,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7018,7 +7003,6 @@
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
       "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -7553,7 +7537,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -8376,7 +8359,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -8801,7 +8783,6 @@
       "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-2.9.0.tgz",
       "integrity": "sha512-OpcaUTCLmHuVuBcyNckKfH5B0oA4JUavb/M/8n9iAvanJYNQkrVm4pvyX0SUaqkBG4dnWHKt7p50B3ngAG2Rfw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^2.0.0",
         "fault": "^2.0.0",
@@ -10256,7 +10237,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -10440,7 +10420,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
       "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -10470,7 +10449,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
       "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -10531,7 +10509,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.3.tgz",
       "integrity": "sha512-SqMiYMUQNNBP9kfPhLO8WXEk/fon47vc52FQsUiJzTBuyjKgEcoAwMyF04eQ4WZ2ArMn7+ReypYL60aKngbACQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -11720,7 +11697,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11983,7 +11959,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -201,21 +201,24 @@
           "default": 0,
           "minimum": 0,
           "maximum": 72,
-          "description": "Space before paragraphs in points (margin-top). Default: 0pt"
+          "description": "Space before paragraphs in points (margin-top). Default: 0pt",
+          "scope": "application"
         },
         "markdownForHumans.paragraph.spacingAfter": {
           "type": "number",
           "default": 0,
           "minimum": 0,
           "maximum": 72,
-          "description": "Space after paragraphs in points (margin-bottom). Default: 0pt"
+          "description": "Space after paragraphs in points (margin-bottom). Default: 0pt",
+          "scope": "application"
         },
         "markdownForHumans.zoom": {
           "type": "number",
           "default": 100,
           "minimum": 50,
           "maximum": 200,
-          "description": "Zoom level for the editor as a percentage. 100 = default size, 150 = 50% larger, etc."
+          "description": "Zoom level for the editor as a percentage. 100 = default size, 150 = 50% larger, etc.",
+          "scope": "application"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -176,6 +176,27 @@
           "default": true,
           "description": "Enable the image hover overlay that shades images and displays metadata (resolution, file size, etc.) on hover.",
           "scope": "application"
+        },
+        "markdownForHumans.paragraph.spacingBefore": {
+          "type": "number",
+          "default": 0,
+          "minimum": 0,
+          "maximum": 72,
+          "description": "Space before paragraphs in points (margin-top). Default: 0pt"
+        },
+        "markdownForHumans.paragraph.spacingAfter": {
+          "type": "number",
+          "default": 0,
+          "minimum": 0,
+          "maximum": 72,
+          "description": "Space after paragraphs in points (margin-bottom). Default: 0pt"
+        },
+        "markdownForHumans.zoom": {
+          "type": "number",
+          "default": 100,
+          "minimum": 50,
+          "maximum": 200,
+          "description": "Zoom level for the editor as a percentage. 100 = default size, 150 = 50% larger, etc."
         }
       }
     }

--- a/src/__tests__/editor/undoSync.test.ts
+++ b/src/__tests__/editor/undoSync.test.ts
@@ -198,6 +198,9 @@ describe('MarkdownEditorProvider undo/redo safety', () => {
       imagePath: 'images',
       imagePathBase: 'relativeToDocument',
       showImageHoverOverlay: true,
+      paragraphSpacingBefore: 0,
+      paragraphSpacingAfter: 0,
+      zoom: 100,
     });
   });
 
@@ -236,6 +239,9 @@ describe('MarkdownEditorProvider undo/redo safety', () => {
       imagePath: 'images',
       imagePathBase: 'relativeToDocument',
       showImageHoverOverlay: false,
+      paragraphSpacingBefore: 0,
+      paragraphSpacingAfter: 0,
+      zoom: 100,
     });
 
     getConfigurationSpy.mockRestore();

--- a/src/editor/MarkdownEditorProvider.ts
+++ b/src/editor/MarkdownEditorProvider.ts
@@ -403,7 +403,10 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
         e.affectsConfiguration('markdownForHumans.imageResize.skipWarning') ||
         e.affectsConfiguration('markdownForHumans.imagePath') ||
         e.affectsConfiguration('markdownForHumans.imagePathBase') ||
-        e.affectsConfiguration('markdownForHumans.imagePreview.hover.enabled')
+        e.affectsConfiguration('markdownForHumans.imagePreview.hover.enabled') ||
+        e.affectsConfiguration('markdownForHumans.paragraph.spacingBefore') ||
+        e.affectsConfiguration('markdownForHumans.paragraph.spacingAfter') ||
+        e.affectsConfiguration('markdownForHumans.zoom')
       ) {
         const config = vscode.workspace.getConfiguration();
         const skipWarning = config.get<boolean>('markdownForHumans.imageResize.skipWarning', false);
@@ -416,12 +419,24 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
           'markdownForHumans.imagePreview.hover.enabled',
           true
         );
+        const paragraphSpacingBefore = config.get<number>(
+          'markdownForHumans.paragraph.spacingBefore',
+          0
+        );
+        const paragraphSpacingAfter = config.get<number>(
+          'markdownForHumans.paragraph.spacingAfter',
+          0
+        );
+        const zoom = config.get<number>('markdownForHumans.zoom', 100);
         webviewPanel.webview.postMessage({
           type: 'settingsUpdate',
           skipResizeWarning: skipWarning,
           imagePath: imagePath,
           imagePathBase: imagePathBase,
           showImageHoverOverlay: showImageHoverOverlay,
+          paragraphSpacingBefore: paragraphSpacingBefore,
+          paragraphSpacingAfter: paragraphSpacingAfter,
+          zoom: zoom,
         });
       }
     });
@@ -487,6 +502,12 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
       'markdownForHumans.imagePreview.hover.enabled',
       true
     );
+    const paragraphSpacingBefore = config.get<number>(
+      'markdownForHumans.paragraph.spacingBefore',
+      0
+    );
+    const paragraphSpacingAfter = config.get<number>('markdownForHumans.paragraph.spacingAfter', 0);
+    const zoom = config.get<number>('markdownForHumans.zoom', 100);
 
     webview.postMessage({
       type: 'update',
@@ -495,6 +516,9 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
       imagePath: imagePath,
       imagePathBase: imagePathBase,
       showImageHoverOverlay: showImageHoverOverlay,
+      paragraphSpacingBefore: paragraphSpacingBefore,
+      paragraphSpacingAfter: paragraphSpacingAfter,
+      zoom: zoom,
     });
   }
 
@@ -530,12 +554,24 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
           'markdownForHumans.imagePreview.hover.enabled',
           true
         );
+        const paragraphSpacingBefore = config.get<number>(
+          'markdownForHumans.paragraph.spacingBefore',
+          0
+        );
+        const paragraphSpacingAfter = config.get<number>(
+          'markdownForHumans.paragraph.spacingAfter',
+          0
+        );
+        const zoom = config.get<number>('markdownForHumans.zoom', 100);
         webview.postMessage({
           type: 'settingsUpdate',
           skipResizeWarning: skipWarning,
           imagePath: imagePath,
           imagePathBase: imagePathBase,
           showImageHoverOverlay: showImageHoverOverlay,
+          paragraphSpacingBefore: paragraphSpacingBefore,
+          paragraphSpacingAfter: paragraphSpacingAfter,
+          zoom: zoom,
         });
         break;
       }

--- a/src/webview/editor.css
+++ b/src/webview/editor.css
@@ -126,7 +126,7 @@
 
   /* Consistent spacing after headings */
   .markdown-editor :is(h1, h2, h3, h4, h5, h6) + p {
-    margin-top: 0.5em;
+    margin-top: var(--md-paragraph-spacing-before, 0.5em);
   }
   
   /* ============================================

--- a/src/webview/editor.css
+++ b/src/webview/editor.css
@@ -26,8 +26,8 @@
     --md-focus: var(--vscode-focusBorder);
     --md-selection: var(--vscode-editor-selectionBackground);
   
-    /* Typography and layout */
-    --md-base-size: var(--vscode-editor-font-size, 14px);
+    /* Typography and layout — zoom override takes priority if set by JS */
+    --md-base-size: var(--md-base-size-override, var(--vscode-editor-font-size, 14px));
   
     line-height: 1.58;
     letter-spacing: -0.003em;
@@ -102,6 +102,8 @@
   
   .markdown-editor p {
     margin: 0;
+    margin-top: var(--md-paragraph-spacing-before, 0pt);
+    margin-bottom: var(--md-paragraph-spacing-after, 0pt);
     line-height: 1.58;
     font-size: calc(var(--md-base-size) * 1.2);
   }

--- a/src/webview/editor.ts
+++ b/src/webview/editor.ts
@@ -1662,7 +1662,14 @@ window.addEventListener('openExtensionSettings', () => {
   vscode.postMessage({ type: 'openExtensionSettings' });
 });
 
-// Zoom: applies zoom level from markdownForHumans.zoom setting (percentage, 100 = default)
+/**
+ * Applies the editor zoom level by scaling the base font size.
+ * Sets the `--md-base-size-override` CSS custom property on the document root,
+ * which takes priority over the default VS Code editor font size.
+ * At 100% the override is removed so the default size applies.
+ *
+ * @param percent - Zoom level as a percentage (50–200). 100 = default size.
+ */
 function applyZoomLevel(percent: number) {
   if (percent === 100) {
     document.documentElement.style.removeProperty('--md-base-size-override');

--- a/src/webview/editor.ts
+++ b/src/webview/editor.ts
@@ -968,23 +968,7 @@ window.addEventListener('message', (event: MessageEvent) => {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (window as any).imagePathBase = message.imagePathBase;
         }
-        // Apply paragraph spacing settings
-        if (typeof message.paragraphSpacingBefore === 'number') {
-          document.documentElement.style.setProperty(
-            '--md-paragraph-spacing-before',
-            `${message.paragraphSpacingBefore}pt`
-          );
-        }
-        if (typeof message.paragraphSpacingAfter === 'number') {
-          document.documentElement.style.setProperty(
-            '--md-paragraph-spacing-after',
-            `${message.paragraphSpacingAfter}pt`
-          );
-        }
-        // Apply zoom level setting
-        if (typeof message.zoom === 'number') {
-          applyZoomLevel(message.zoom);
-        }
+        applyEditorSettings(message);
         // Initialize editor with first payload to seed undo history correctly
         if (!editor) {
           if (isDomReady) {
@@ -1016,23 +1000,7 @@ window.addEventListener('message', (event: MessageEvent) => {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (window as any).showImageHoverOverlay = message.showImageHoverOverlay;
         }
-        // Update paragraph spacing settings
-        if (typeof message.paragraphSpacingBefore === 'number') {
-          document.documentElement.style.setProperty(
-            '--md-paragraph-spacing-before',
-            `${message.paragraphSpacingBefore}pt`
-          );
-        }
-        if (typeof message.paragraphSpacingAfter === 'number') {
-          document.documentElement.style.setProperty(
-            '--md-paragraph-spacing-after',
-            `${message.paragraphSpacingAfter}pt`
-          );
-        }
-        // Apply zoom level setting
-        if (typeof message.zoom === 'number') {
-          applyZoomLevel(message.zoom);
-        }
+        applyEditorSettings(message);
         break;
       case 'imageResized': {
         // Handle image resize completion
@@ -1661,6 +1629,29 @@ window.addEventListener('openSourceView', () => {
 window.addEventListener('openExtensionSettings', () => {
   vscode.postMessage({ type: 'openExtensionSettings' });
 });
+
+/**
+ * Applies paragraph spacing and zoom settings from an incoming message.
+ * Called from both the `update` and `settingsUpdate` handlers.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function applyEditorSettings(message: Record<string, any>) {
+  if (typeof message.paragraphSpacingBefore === 'number') {
+    document.documentElement.style.setProperty(
+      '--md-paragraph-spacing-before',
+      `${message.paragraphSpacingBefore}pt`
+    );
+  }
+  if (typeof message.paragraphSpacingAfter === 'number') {
+    document.documentElement.style.setProperty(
+      '--md-paragraph-spacing-after',
+      `${message.paragraphSpacingAfter}pt`
+    );
+  }
+  if (typeof message.zoom === 'number') {
+    applyZoomLevel(message.zoom);
+  }
+}
 
 /**
  * Applies the editor zoom level by scaling the base font size.

--- a/src/webview/editor.ts
+++ b/src/webview/editor.ts
@@ -883,6 +883,23 @@ window.addEventListener('message', (event: MessageEvent) => {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (window as any).imagePathBase = message.imagePathBase;
         }
+        // Apply paragraph spacing settings
+        if (typeof message.paragraphSpacingBefore === 'number') {
+          document.documentElement.style.setProperty(
+            '--md-paragraph-spacing-before',
+            `${message.paragraphSpacingBefore}pt`
+          );
+        }
+        if (typeof message.paragraphSpacingAfter === 'number') {
+          document.documentElement.style.setProperty(
+            '--md-paragraph-spacing-after',
+            `${message.paragraphSpacingAfter}pt`
+          );
+        }
+        // Apply zoom level setting
+        if (typeof message.zoom === 'number') {
+          applyZoomLevel(message.zoom);
+        }
         // Initialize editor with first payload to seed undo history correctly
         if (!editor) {
           if (isDomReady) {
@@ -913,6 +930,23 @@ window.addEventListener('message', (event: MessageEvent) => {
         if (typeof message.showImageHoverOverlay === 'boolean') {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (window as any).showImageHoverOverlay = message.showImageHoverOverlay;
+        }
+        // Update paragraph spacing settings
+        if (typeof message.paragraphSpacingBefore === 'number') {
+          document.documentElement.style.setProperty(
+            '--md-paragraph-spacing-before',
+            `${message.paragraphSpacingBefore}pt`
+          );
+        }
+        if (typeof message.paragraphSpacingAfter === 'number') {
+          document.documentElement.style.setProperty(
+            '--md-paragraph-spacing-after',
+            `${message.paragraphSpacingAfter}pt`
+          );
+        }
+        // Apply zoom level setting
+        if (typeof message.zoom === 'number') {
+          applyZoomLevel(message.zoom);
         }
         break;
       case 'imageResized': {
@@ -1520,6 +1554,22 @@ window.addEventListener('openSourceView', () => {
 window.addEventListener('openExtensionSettings', () => {
   vscode.postMessage({ type: 'openExtensionSettings' });
 });
+
+// Zoom: applies zoom level from markdownForHumans.zoom setting (percentage, 100 = default)
+function applyZoomLevel(percent: number) {
+  if (percent === 100) {
+    document.documentElement.style.removeProperty('--md-base-size-override');
+  } else {
+    const rawSize = getComputedStyle(document.documentElement)
+      .getPropertyValue('--vscode-editor-font-size')
+      .trim();
+    const basePx = parseFloat(rawSize) || 14;
+    document.documentElement.style.setProperty(
+      '--md-base-size-override',
+      `${basePx * (percent / 100)}px`
+    );
+  }
+}
 
 // Handle export document from toolbar button
 window.addEventListener('exportDocument', async (event: Event) => {


### PR DESCRIPTION
## Summary

Adds three new user-configurable settings to improve the reading/writing experience:

### New Settings

| Setting | Type | Default | Description |
|---------|------|---------|-------------|
| `markdownForHumans.paragraph.spacingBefore` | number | 0 | Space before paragraphs in points (0–72pt) |
| `markdownForHumans.paragraph.spacingAfter` | number | 0 | Space after paragraphs in points (0–72pt) |
| `markdownForHumans.zoom` | number | 100 | Editor zoom as percentage (50–200%) |

### How it works

- Settings are read in `MarkdownEditorProvider` and sent to the webview via the existing `settingsUpdate` message pipeline
- CSS custom properties (`--md-paragraph-spacing-before`, `--md-paragraph-spacing-after`, `--md-base-size-override`) are set on `document.documentElement` and consumed by `.markdown-editor` styles
- Changes apply live without reload when settings are modified

### Testing

- All existing tests pass
- Updated `undoSync.test.ts` to include new payload fields
- Manually tested in Extension Development Host (F5)

### Checklist

- [x] Tests passing (`npm test`)
- [x] Linting passes (`npm run lint`)
- [x] Build succeeds (`npm run build:debug`)
- [x] Manually verified in VS Code