### PR TITLE
ci: pin third-party actions to commit SHAs and tighten permissions (fixes pwn_request risk)

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,11 +1,37 @@
 name: AI Code Review
 
+# SECURITY NOTE — pull_request_target trust model
+# ------------------------------------------------
+# `pull_request_target` evaluates the workflow file from the BASE branch (`main`),
+# not from the PR head. This is intentional: it grants access to repository
+# secrets (GEMINI_API_KEY) so a PR from a fork can be reviewed.
+#
+# The risk this trust grant carries is the "pwn_request" pattern
+# (https://securitylab.github.com/research/github-actions-preventing-pwn-requests/):
+# any third-party action invoked here runs with secrets in scope. If a
+# referenced action is compromised — or its tag is moved to point at malicious
+# code — the secret leaks on every PR, including from forks.
+#
+# Mitigations applied:
+#   1. Every third-party action below is pinned to a full commit SHA, not a
+#      moveable tag. A maintainer can update the SHA deliberately when bumping
+#      versions; an attacker who only controls the tag namespace cannot
+#      hijack the run.
+#   2. The top-level `permissions:` block is set to the minimum required
+#      (read repo contents, write PR comments). `id-token`, `actions`, etc.
+#      are explicitly not granted.
+#   3. We do NOT execute PR code (no `npm install`, no `node …`, no shell
+#      that interprets PR content). The AI reviewer reads files only.
+#
+# When updating action versions, look up the new commit SHA and pin to it,
+# e.g. `gh api repos/<owner>/<repo>/git/refs/tags/<tag> --jq .object.sha`.
+
 on:
-  # pull_request_target runs the workflow from the BASE branch (main), not the
-  # fork. This gives it access to repository secrets while reviewing fork PRs.
-  # Safe here because the action only reads files, never executes repo code.
   pull_request_target:
     types: [opened, synchronize, reopened]
+
+# Default to no permissions; the single job opts in to exactly what it needs.
+permissions: {}
 
 concurrency:
   group: ai-review-${{ github.event.pull_request.number }}
@@ -18,14 +44,15 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      # Checkout the PR's merge commit so the action sees the fork's changes.
-      # This is read-only context for the AI reviewer, no code is executed.
-      - uses: actions/checkout@v4
+      # actions/checkout@v4 — pinned to commit SHA (tag v4)
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
           fetch-depth: 0
+          persist-credentials: false
 
-      - uses: concretios/ai-pr-reviewer@v1
+      # concretios/ai-pr-reviewer@v1 — pinned to commit SHA (tag v1)
+      - uses: concretios/ai-pr-reviewer@7d151e668dce51de3022b95ecfab53b0a69cc5a2
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
           context_depth: changed-files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,24 +1,38 @@
 name: CI
 
+# All third-party actions are pinned to commit SHAs (not tags) to defend
+# against tag-hijack supply-chain attacks. When bumping versions, resolve
+# the new SHA via:
+#   gh api repos/<owner>/<repo>/git/refs/tags/<tag> --jq .object.sha
+
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
 
+# Default to no permissions; each job opts in to exactly what it needs.
+permissions: {}
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     strategy:
       matrix:
         node-version: [18.x, 20.x]
 
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        # actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -33,7 +47,8 @@ jobs:
         run: npm run test:coverage
 
       - name: Upload coverage reports
-        uses: codecov/codecov-action@v3
+        # codecov/codecov-action@v3
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457
         if: matrix.node-version == '20.x'
         with:
           files: ./coverage/lcov.info
@@ -46,12 +61,18 @@ jobs:
   package:
     runs-on: ubuntu-latest
     needs: test
+    permissions:
+      contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v4
+        # actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 20.x
           cache: 'npm'
@@ -63,7 +84,8 @@ jobs:
         run: npm run package:release
 
       - name: Upload VSIX artifact
-        uses: actions/upload-artifact@v4
+        # actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: vsix-package
           path: '*.vsix'


### PR DESCRIPTION
Fixes #37.

## Summary

Pins every third-party action used in `.github/workflows/{ai-review,ci}.yml` to a full commit SHA, adds workflow-level `permissions: {}` deny-by-default, and disables `persist-credentials` on every checkout. This closes the [pwn_request](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) attack surface in `ai-review.yml`, which currently allows any tag-namespace compromise of `concretios/ai-pr-reviewer` (or `actions/checkout`) to leak `GEMINI_API_KEY` to attacker-controlled fork PRs.

The full threat model and references are in #37.

## Changes

`.github/workflows/ai-review.yml`

- `actions/checkout@v4` → `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5`
- `concretios/ai-pr-reviewer@v1` → `concretios/ai-pr-reviewer@7d151e668dce51de3022b95ecfab53b0a69cc5a2`
- Added workflow-level `permissions: {}`; the `review` job opts in to `contents: read` + `pull-requests: write`.
- Added `persist-credentials: false` to the checkout step.
- Replaced the existing comment with an expanded SECURITY NOTE explaining the trust model and instructions for safely bumping versions.

`.github/workflows/ci.yml`

- `actions/checkout@v4` → `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5` (both jobs)
- `actions/setup-node@v4` → `actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020` (both jobs)
- `codecov/codecov-action@v3` → `codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457`
- `actions/upload-artifact@v4` → `actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02`
- Added workflow-level `permissions: {}`; both jobs opt in to `contents: read`.
- Added `persist-credentials: false` to every checkout.

Each pin is paired with a comment showing the original tag (e.g. `# actions/checkout@v4`) so future bumps stay auditable.

All SHAs were resolved via `gh api repos/<owner>/<repo>/git/refs/tags/<tag>` against the tag value already in the file, so this PR is a **pure version-pin: no functional change, no version bump**. CI and the AI reviewer should behave identically to today.

## Test plan

- [ ] CI green on this PR (lint, tests, build, package — the same workflows being modified).
- [ ] Maintainer confirms the AI reviewer still runs and posts a comment on this PR (this exercises the new `ai-review.yml` end-to-end on a fork PR — the exact scenario the hardening is designed for).
- [ ] No regression in the upload-artifact step on the `package` job (VSIX should still appear under "Artifacts").

## Future work (out of scope)

- Split `ai-review.yml` into a `pull_request`-triggered job (no secrets, can checkout PR head) and a `pull_request_target` job (has secrets, only posts the result). This would require `concretios/ai-pr-reviewer` to support reading inputs from an artifact instead of the workspace, so it is left as a follow-up.
- Add a `SECURITY.md` with a private reporting channel for any future findings.
- Move marketplace publishing into a SHA-pinned GitHub Actions workflow with [`npm publish --provenance`](https://docs.npmjs.com/generating-provenance-statements) so the shipped VSIX is verifiably built from a green commit.

## Background — how this PR was produced

The change came out of a security review of the v0.1.7 extension. I verified locally that:

1. `npm ci && npm run package:release` still produces a valid VSIX (12 files, 2 MB, identical inventory to upstream `0.1.7`).
2. The packaged extension installs cleanly into Cursor 3.2.16 (`cursor --install-extension markdown-for-humans-0.1.7.vsix`) and the WYSIWYG editor opens normally on existing markdown files.

Happy to address comments — and if you'd prefer a different commit message style or want the SECURITY NOTE shorter, just say the word.
