### PR TITLE
fix(security): close path-traversal in image rename/resize and sandbox PDF export

### DIFF
--- a/src/__tests__/editor/imageResizeInPlace.test.ts
+++ b/src/__tests__/editor/imageResizeInPlace.test.ts
@@ -5,6 +5,7 @@ jest.mock('vscode', () => ({
   window: {
     showErrorMessage: jest.fn(),
     showInformationMessage: jest.fn(),
+    showWarningMessage: jest.fn(),
   },
   workspace: {
     getWorkspaceFolder: jest.fn(),
@@ -244,7 +245,7 @@ describe('MarkdownEditorProvider - Resize (in-place + workspace backups)', () =>
     );
   });
 
-  it('creates backup for external image with _external suffix', async () => {
+  it('creates backup for external image with _external suffix (after user confirms)', async () => {
     const document = createMockTextDocument('# test');
 
     (vscode.workspace.fs.stat as jest.Mock).mockImplementation((uri: vscode.Uri) => {
@@ -259,6 +260,9 @@ describe('MarkdownEditorProvider - Resize (in-place + workspace backups)', () =>
     (vscode.workspace.fs.readFile as jest.Mock).mockResolvedValue(new Uint8Array([9, 9, 9]));
     (vscode.workspace.fs.createDirectory as jest.Mock).mockResolvedValue(undefined);
     (vscode.workspace.fs.writeFile as jest.Mock).mockResolvedValue(undefined);
+    // SECURITY contract: writes outside the workspace are gated by a modal
+    // confirm. Simulate the user clicking "Overwrite".
+    (vscode.window.showWarningMessage as jest.Mock).mockResolvedValue('Overwrite');
 
     const message = {
       type: 'resizeImage',
@@ -281,7 +285,14 @@ describe('MarkdownEditorProvider - Resize (in-place + workspace backups)', () =>
       }
     ).handleResizeImage(message, document, mockWebview);
 
-    // Should create backup in workspace with _external suffix
+    // The user must have been shown the resolved external path before write.
+    expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
+      expect.stringContaining('/Users/external/image.png'),
+      expect.objectContaining({ modal: true }),
+      'Overwrite'
+    );
+
+    // After confirmation, backup is created in workspace with _external suffix.
     expect(vscode.workspace.fs.writeFile).toHaveBeenCalledWith(
       expect.objectContaining({
         fsPath: expect.stringMatching(
@@ -290,6 +301,45 @@ describe('MarkdownEditorProvider - Resize (in-place + workspace backups)', () =>
       }),
       new Uint8Array([9, 9, 9])
     );
+  });
+
+  it('does NOT write when user cancels the external-resize confirm prompt (security)', async () => {
+    const document = createMockTextDocument('# test');
+
+    (vscode.workspace.fs.stat as jest.Mock).mockImplementation((uri: vscode.Uri) => {
+      if (uri.fsPath === '/etc/passwd') {
+        return Promise.resolve({} as vscode.FileStat);
+      }
+      return Promise.reject(new Error('File not found'));
+    });
+    (vscode.workspace.fs.readFile as jest.Mock).mockResolvedValue(new Uint8Array([1, 2, 3]));
+    (vscode.workspace.fs.writeFile as jest.Mock).mockResolvedValue(undefined);
+    // User dismisses the dialog (returns undefined).
+    (vscode.window.showWarningMessage as jest.Mock).mockResolvedValue(undefined);
+
+    const message = {
+      type: 'resizeImage',
+      imagePath: '/etc/passwd',
+      absolutePath: '/etc/passwd',
+      newWidth: 1,
+      newHeight: 1,
+      imageData: 'data:image/png;base64,AAAA',
+    };
+
+    await (
+      provider as unknown as {
+        handleResizeImage: (
+          message: unknown,
+          doc: vscode.TextDocument,
+          webview: { postMessage: jest.Mock }
+        ) => Promise<void>;
+      }
+    ).handleResizeImage(message, document, mockWebview);
+
+    // The prompt MUST have been shown (defense-in-depth UX).
+    expect(vscode.window.showWarningMessage).toHaveBeenCalled();
+    // No write to /etc/passwd or anywhere else.
+    expect(vscode.workspace.fs.writeFile).not.toHaveBeenCalled();
   });
 
   it('handles multiple rapid resizes with collision detection', async () => {

--- a/src/__tests__/editor/pathContainment.test.ts
+++ b/src/__tests__/editor/pathContainment.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Path-Containment / Path-Traversal Defense Tests
+ *
+ * These tests guard the security boundary used by image rename, resize, and
+ * file-link handlers. The handlers receive paths from messages whose ultimate
+ * source is the markdown content the user opened — which can be hostile.
+ *
+ * Without containment checks, a malicious markdown file with
+ * `![pet](../../../../etc/passwd)` (or any traversal payload) lets a single
+ * user click ("Rename image…", "Resize image…") rename / overwrite files
+ * completely outside the workspace. See SECURITY review §H1, §H2.
+ *
+ * Contract:
+ *   isPathContainedWithin(target, root)
+ *     - returns TRUE iff `target` is `root` itself or strictly inside `root`
+ *     - returns FALSE for any path that escapes `root` via `..`, absolute
+ *       paths to other roots, symlink-style "looks-similar" prefixes
+ *       (e.g. /workspace-evil for root /workspace), or by drive-letter on Win
+ *     - operates on already-resolved absolute paths (caller is responsible
+ *       for path.resolve() before calling)
+ */
+
+import * as path from 'path';
+import { isPathContainedWithin } from '../../editor/MarkdownEditorProvider';
+
+describe('isPathContainedWithin (path-traversal defense)', () => {
+  const ROOT = path.resolve('/tmp/workspace');
+
+  describe('legitimate paths inside the root', () => {
+    it('accepts the root itself', () => {
+      expect(isPathContainedWithin(ROOT, ROOT)).toBe(true);
+    });
+
+    it('accepts a direct child file', () => {
+      expect(isPathContainedWithin(path.join(ROOT, 'image.png'), ROOT)).toBe(true);
+    });
+
+    it('accepts a deeply nested file', () => {
+      expect(isPathContainedWithin(path.join(ROOT, 'a', 'b', 'c', 'image.png'), ROOT)).toBe(true);
+    });
+
+    it('accepts a path with redundant segments that resolve inside', () => {
+      const wobbly = path.resolve(ROOT, 'a', '..', 'b', 'image.png');
+      expect(isPathContainedWithin(wobbly, ROOT)).toBe(true);
+    });
+  });
+
+  describe('attack: traversal via "../" sequences', () => {
+    it('rejects "../etc/passwd" attack', () => {
+      const attack = path.resolve(ROOT, '..', '..', '..', 'etc', 'passwd');
+      expect(isPathContainedWithin(attack, ROOT)).toBe(false);
+    });
+
+    it('rejects an absolute path outside the root', () => {
+      expect(isPathContainedWithin('/etc/passwd', ROOT)).toBe(false);
+    });
+
+    it('rejects a path under the user home', () => {
+      expect(isPathContainedWithin('/Users/victim/.ssh/id_ed25519', ROOT)).toBe(false);
+    });
+
+    it('rejects ".." resolving to the parent of root', () => {
+      expect(isPathContainedWithin(path.dirname(ROOT), ROOT)).toBe(false);
+    });
+  });
+
+  describe('attack: prefix-confusion (the classic startsWith bug)', () => {
+    /**
+     * The naive check `target.startsWith(root)` mis-classifies sibling
+     * directories whose names *begin with* the root's name. This is the
+     * bug we are explicitly defending against.
+     */
+    it('rejects a sibling whose name shares the root prefix', () => {
+      // /tmp/workspace-evil starts with /tmp/workspace, but is NOT inside it
+      const sibling = path.resolve('/tmp/workspace-evil/file.png');
+      expect(isPathContainedWithin(sibling, ROOT)).toBe(false);
+    });
+
+    it('rejects a sibling whose name extends the root by characters', () => {
+      const sibling = path.resolve('/tmp/workspaceX/file.png');
+      expect(isPathContainedWithin(sibling, ROOT)).toBe(false);
+    });
+  });
+
+  describe('inputs', () => {
+    it('returns false for empty target', () => {
+      expect(isPathContainedWithin('', ROOT)).toBe(false);
+    });
+
+    it('returns false for empty root', () => {
+      expect(isPathContainedWithin('/tmp/workspace/x', '')).toBe(false);
+    });
+  });
+});

--- a/src/__tests__/features/exportHtmlSanitization.test.ts
+++ b/src/__tests__/features/exportHtmlSanitization.test.ts
@@ -1,0 +1,170 @@
+/**
+ * PDF/HTML Export Sanitization Tests
+ *
+ * The PDF export pipeline takes the editor's HTML and renders it via Chrome.
+ * Combined with `--allow-file-access-from-files` (now removed) and the lack
+ * of a CSP on the exported page, ANY active content (script, on* handler,
+ * javascript: URI, foreign iframe/object/embed) in attacker-supplied
+ * markdown was a vector to exfiltrate local files into the user's PDF.
+ *
+ * See SECURITY review §H3.
+ *
+ * Contract:
+ *   sanitizeExportHtml(html: string): string
+ *     - removes <script>, <iframe>, <object>, <embed>, <link>, <meta>
+ *     - removes every on* event handler attribute
+ *     - rewrites href / src / xlink:href / data attributes whose value is a
+ *       javascript: or data:text/html: scheme to an empty string
+ *     - preserves benign markup: paragraphs, lists, tables, code blocks,
+ *       images, anchors, span/div with class/style/data-* attrs
+ */
+
+import { sanitizeExportHtml } from '../../features/documentExport';
+
+describe('sanitizeExportHtml', () => {
+  describe('strips active content', () => {
+    it('removes <script> tags entirely (including contents)', () => {
+      const out = sanitizeExportHtml(
+        '<p>before</p><script>fetch("file:///etc/passwd")</script><p>after</p>'
+      );
+      expect(out).not.toMatch(/<script/i);
+      expect(out).not.toMatch(/file:\/\/\/etc\/passwd/);
+      expect(out).toContain('before');
+      expect(out).toContain('after');
+    });
+
+    it('removes <iframe>', () => {
+      const out = sanitizeExportHtml('<p>hi</p><iframe src="file:///etc/passwd"></iframe>');
+      expect(out).not.toMatch(/<iframe/i);
+    });
+
+    it('removes <object> and <embed>', () => {
+      const out = sanitizeExportHtml(
+        '<object data="file:///etc/passwd"></object><embed src="file:///etc/passwd">'
+      );
+      expect(out).not.toMatch(/<object/i);
+      expect(out).not.toMatch(/<embed/i);
+    });
+
+    it('removes <link> and <meta> (could redirect or refresh)', () => {
+      const out = sanitizeExportHtml(
+        '<meta http-equiv="refresh" content="0;url=file:///etc/passwd"><link rel="import" href="file:///etc/passwd">'
+      );
+      expect(out).not.toMatch(/<meta/i);
+      expect(out).not.toMatch(/<link/i);
+    });
+  });
+
+  describe('strips inline event handlers', () => {
+    it('removes onerror on <img>', () => {
+      const out = sanitizeExportHtml(
+        '<img src="x" onerror="fetch(\'file:///etc/passwd\').then(r=>r.text()).then(t=>document.title=t)">'
+      );
+      expect(out).not.toMatch(/onerror/i);
+      expect(out).not.toMatch(/file:\/\/\/etc\/passwd/);
+      // benign attributes remain
+      expect(out).toMatch(/<img\s/i);
+      expect(out).toMatch(/src="x"/);
+    });
+
+    it('removes onload on <body> / <svg>', () => {
+      const out = sanitizeExportHtml('<svg onload="alert(1)"><circle r="10"/></svg>');
+      expect(out).not.toMatch(/onload/i);
+    });
+
+    it('removes onclick on <a>', () => {
+      const out = sanitizeExportHtml('<a href="#" onclick="evil()">click</a>');
+      expect(out).not.toMatch(/onclick/i);
+    });
+
+    it('strips uppercase / mixed-case ON* handlers (HTML attrs are case-insensitive)', () => {
+      const out = sanitizeExportHtml('<img src="x" OnError="alert(1)">');
+      expect(out).not.toMatch(/onerror/i);
+    });
+  });
+
+  describe('strips dangerous URI schemes', () => {
+    it('strips javascript: from <a href>', () => {
+      const out = sanitizeExportHtml('<a href="javascript:alert(1)">x</a>');
+      expect(out).not.toMatch(/javascript:/i);
+    });
+
+    it('strips javascript: from <img src>', () => {
+      const out = sanitizeExportHtml('<img src="javascript:alert(1)">');
+      expect(out).not.toMatch(/javascript:/i);
+    });
+
+    it('strips file: from <a href>', () => {
+      const out = sanitizeExportHtml('<a href="file:///etc/passwd">click</a>');
+      expect(out).not.toMatch(/file:\/\/\//i);
+    });
+
+    it('preserves https: and mailto: URIs', () => {
+      const out = sanitizeExportHtml(
+        '<a href="https://example.com">x</a><a href="mailto:a@b.c">y</a>'
+      );
+      expect(out).toContain('https://example.com');
+      expect(out).toContain('mailto:a@b.c');
+    });
+
+    it('preserves data: image URIs (used for inlined PNGs)', () => {
+      const out = sanitizeExportHtml('<img src="data:image/png;base64,iVBORw0KGgo=">');
+      expect(out).toContain('data:image/png;base64,iVBORw0KGgo=');
+    });
+
+    it('strips data:text/html (active content disguised as data URI)', () => {
+      const out = sanitizeExportHtml(
+        '<iframe src="data:text/html,<script>alert(1)</script>"></iframe>'
+      );
+      expect(out).not.toMatch(/<iframe/i);
+      // Even if the iframe-strip didn't catch it, the data:text/html scheme
+      // must not survive on any element.
+      expect(out).not.toMatch(/data:text\/html/i);
+    });
+  });
+
+  describe('preserves benign markup', () => {
+    it('keeps headings, paragraphs, code, tables, lists', () => {
+      const html = `
+        <h1>Title</h1>
+        <p>Body with <strong>bold</strong> and <em>italic</em>.</p>
+        <pre><code class="language-ts">const x = 1;</code></pre>
+        <table><thead><tr><th>A</th></tr></thead><tbody><tr><td>1</td></tr></tbody></table>
+        <ul><li>one</li><li>two</li></ul>
+      `;
+      const out = sanitizeExportHtml(html);
+      expect(out).toContain('<h1>');
+      expect(out).toContain('<strong>');
+      expect(out).toContain('<em>');
+      expect(out).toContain('language-ts');
+      expect(out).toContain('<table>');
+      expect(out).toContain('<th>');
+      expect(out).toContain('<td>');
+      expect(out).toContain('<li>');
+    });
+
+    it('keeps relative image paths and alt text', () => {
+      const out = sanitizeExportHtml('<img src="./images/cat.png" alt="A cat">');
+      expect(out).toContain('./images/cat.png');
+      expect(out).toContain('A cat');
+    });
+
+    it('keeps class and style attributes (used by themes / Mermaid SVG)', () => {
+      const out = sanitizeExportHtml('<div class="mermaid" style="color:red">x</div>');
+      expect(out).toContain('class="mermaid"');
+      expect(out).toContain('style="color:red"');
+    });
+  });
+
+  describe('robustness', () => {
+    it('returns empty string for empty input', () => {
+      expect(sanitizeExportHtml('')).toBe('');
+    });
+
+    it('does not throw on malformed HTML', () => {
+      expect(() =>
+        sanitizeExportHtml('<p>unclosed <strong>nested <a href="x">stuff')
+      ).not.toThrow();
+    });
+  });
+});

--- a/src/editor/MarkdownEditorProvider.ts
+++ b/src/editor/MarkdownEditorProvider.ts
@@ -1083,19 +1083,34 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
   }
 
   /**
-   * Check if source is within workspace/document directory (cross-platform)
+   * Check if source is within workspace/document directory (cross-platform).
+   * Thin wrapper over the exported `isPathContainedWithin` helper.
    */
   private isWithinWorkspace(sourcePath: string, basePath: string): boolean {
-    const normalizedSource = path.normalize(sourcePath);
-    const normalizedBase = path.normalize(basePath);
+    return isPathContainedWithin(sourcePath, basePath);
+  }
 
-    // On Windows, ensure case-insensitive comparison
-    // On Mac/Linux, case-sensitive comparison
-    const sourceLower =
-      process.platform === 'win32' ? normalizedSource.toLowerCase() : normalizedSource;
-    const baseLower = process.platform === 'win32' ? normalizedBase.toLowerCase() : normalizedBase;
-
-    return sourceLower.startsWith(baseLower + path.sep) || sourceLower === baseLower;
+  /**
+   * Build the list of allowed roots a file-mutating handler may write to,
+   * for the given document. Used by handleRenameImage / handleResizeImage
+   * to reject paths that escape via `../` from a hostile markdown image
+   * src (see SECURITY review §H1, §H2).
+   */
+  private getAllowedFileRoots(document: vscode.TextDocument): string[] {
+    const roots: string[] = [];
+    const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
+    if (workspaceFolder) {
+      roots.push(workspaceFolder.uri.fsPath);
+    }
+    if (document.uri.scheme === 'file') {
+      roots.push(path.dirname(document.uri.fsPath));
+    }
+    const imageBase = this.getImageBasePath(document);
+    if (imageBase) {
+      roots.push(imageBase);
+    }
+    // De-dupe
+    return Array.from(new Set(roots));
   }
 
   /**
@@ -1406,6 +1421,34 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
         const normalizedPath = normalizeImagePath(imagePath);
         absolutePath = path.resolve(basePath, normalizedPath);
         imageUri = vscode.Uri.file(absolutePath);
+      }
+
+      // SECURITY: gate the write target.
+      // - "Normal" path (no absolutePathFromMessage): must stay inside the
+      //   document/workspace roots. Defends against `<img src="../../etc/x">`.
+      // - "Edit in place" path (absolutePathFromMessage): if the file is
+      //   outside every allowed root, require explicit user confirmation
+      //   showing the resolved path before we write. The webview is the
+      //   only legitimate source of this message, but any extension or
+      //   misbehaving page could send it; a one-click confirm makes the
+      //   destination visible.
+      // See SECURITY review §H2.
+      const allowedRoots = this.getAllowedFileRoots(document);
+      const insideAllowedRoot = allowedRoots.some(root =>
+        isPathContainedWithin(absolutePath, root)
+      );
+      if (!insideAllowedRoot) {
+        if (!absolutePathFromMessage) {
+          throw new Error(`Refusing to resize image outside the document/workspace: ${imagePath}`);
+        }
+        const choice = await vscode.window.showWarningMessage(
+          `Resize will overwrite a file outside this workspace:\n\n${absolutePath}\n\nProceed?`,
+          { modal: true },
+          'Overwrite'
+        );
+        if (choice !== 'Overwrite') {
+          throw new Error('Resize cancelled by user.');
+        }
       }
 
       // Check if image exists
@@ -1912,6 +1955,14 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
       const absoluteOldPath = path.resolve(basePath, normalizedOldPath);
       const oldUri = vscode.Uri.file(absoluteOldPath);
 
+      // SECURITY: reject paths that escape the document/workspace roots.
+      // Without this, a hostile markdown file could rename arbitrary files
+      // on disk (e.g. ![](../../../../etc/hosts)) on a single user click.
+      const allowedRoots = this.getAllowedFileRoots(document);
+      if (!allowedRoots.some(root => isPathContainedWithin(absoluteOldPath, root))) {
+        throw new Error(`Refusing to rename image outside the document/workspace: ${oldPath}`);
+      }
+
       // Check if old file exists
       try {
         await vscode.workspace.fs.stat(oldUri);
@@ -1930,6 +1981,15 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
       const oldDir = path.dirname(absoluteOldPath);
       const absoluteNewPath = path.join(oldDir, newFilename);
       const newUri = vscode.Uri.file(absoluteNewPath);
+
+      // SECURITY: also confirm the destination is contained. Defends against
+      // a maliciously crafted `newName` (e.g. `../../../etc/passwd`) that
+      // would otherwise escape via the dirname join above.
+      if (!allowedRoots.some(root => isPathContainedWithin(absoluteNewPath, root))) {
+        throw new Error(
+          `Refusing to rename image to a path outside the document/workspace: ${newFilename}`
+        );
+      }
 
       // Check if new file already exists
       let targetExists = false;
@@ -3064,4 +3124,42 @@ export function normalizeImagePath(imagePath: string): string {
       }
     })
     .join('/');
+}
+
+/**
+ * Path-traversal defense.
+ *
+ * Returns true iff `targetAbsolutePath` is `rootAbsolutePath` itself or a
+ * descendant of it. Used by the file-mutating message handlers (rename,
+ * resize) to reject attacker-supplied paths from a hostile markdown
+ * document — e.g. `<img src="../../../../etc/passwd">`.
+ *
+ * Both inputs MUST already be absolute. Caller is responsible for
+ * `path.resolve()` first.
+ *
+ * Notable defense: this is NOT a naive `target.startsWith(root)` check —
+ * that bug would mis-classify `/tmp/workspace-evil` as inside `/tmp/workspace`.
+ * We require either equality or `root + path.sep` as a prefix.
+ */
+export function isPathContainedWithin(
+  targetAbsolutePath: string,
+  rootAbsolutePath: string
+): boolean {
+  if (!targetAbsolutePath || !rootAbsolutePath) {
+    return false;
+  }
+  const normalizedTarget = path.normalize(targetAbsolutePath);
+  const normalizedRoot = path.normalize(rootAbsolutePath);
+
+  // Strip trailing separator from root (path.normalize keeps "/" for "/")
+  const rootNoSep =
+    normalizedRoot.length > 1 && normalizedRoot.endsWith(path.sep)
+      ? normalizedRoot.slice(0, -1)
+      : normalizedRoot;
+
+  // Case-insensitive on Windows; case-sensitive on macOS / Linux
+  const target = process.platform === 'win32' ? normalizedTarget.toLowerCase() : normalizedTarget;
+  const root = process.platform === 'win32' ? rootNoSep.toLowerCase() : rootNoSep;
+
+  return target === root || target.startsWith(root + path.sep);
 }

--- a/src/features/documentExport.ts
+++ b/src/features/documentExport.ts
@@ -15,7 +15,91 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
 import { spawn } from 'child_process';
+import * as cheerio from 'cheerio';
 import { imageSize } from 'image-size';
+
+/**
+ * Strip active content from HTML before passing it to Chrome for PDF rendering.
+ *
+ * The PDF export pipeline takes the editor's HTML and renders it via headless
+ * Chrome with no Content-Security-Policy. Combined with markdown's
+ * permissive `html: true` parser, ANY active content authored in a markdown
+ * file would otherwise execute during export — script tags, event handlers,
+ * iframes pointing at file:// URIs, javascript: hrefs.
+ *
+ * Removing the Chrome flag `--allow-file-access-from-files` (done in this
+ * change) blocks file:// fetches from the rendered page, but defense in
+ * depth still requires us to strip active content so a malicious markdown
+ * file cannot embed credential prompts, fetch external resources, or run
+ * Chrome zero-days against the user during export.
+ *
+ * Implementation uses `cheerio` (already a runtime dep) for parser-level
+ * sanitization. We allow nothing implicitly; instead we deny-list the
+ * specific dangerous tags / attributes / URI schemes. Benign markup
+ * (paragraphs, tables, code, images with relative or data: src, anchors,
+ * style/class) passes through untouched.
+ *
+ * See SECURITY review §H3.
+ */
+export function sanitizeExportHtml(html: string): string {
+  if (!html) {
+    return '';
+  }
+  // Wrap in a sentinel so we can extract just the body fragment back out
+  // without cheerio injecting <html><head><body> wrappers.
+  const $ = cheerio.load(`<div data-md4h-sanitize-root>${html}</div>`);
+
+  // 1) Remove dangerous tags entirely (including their contents).
+  $(
+    'script, iframe, object, embed, link, meta, base, form, input, button, ' +
+      'textarea, frame, frameset, applet, audio, video, source, track, portal'
+  ).remove();
+
+  // 2) Strip every on* event handler and any URL-bearing attribute whose
+  //    value uses a script-bearing scheme.
+  const URL_LIKE_ATTRS = new Set([
+    'href',
+    'src',
+    'srcset',
+    'action',
+    'formaction',
+    'background',
+    'poster',
+    'data',
+    'cite',
+    'longdesc',
+    'usemap',
+    'profile',
+    'manifest',
+    'codebase',
+    'classid',
+    'icon',
+    'xlink:href',
+  ]);
+  const DANGEROUS_SCHEME = /^\s*(javascript|file|vbscript|data:text\/html)\s*:/i;
+
+  $('*').each((_, el) => {
+    const tagEl = el as { attribs?: Record<string, string> };
+    if (!tagEl.attribs) {
+      return;
+    }
+    for (const attrName of Object.keys(tagEl.attribs)) {
+      const lower = attrName.toLowerCase();
+      if (lower.startsWith('on')) {
+        $(el).removeAttr(attrName);
+        continue;
+      }
+      if (URL_LIKE_ATTRS.has(lower)) {
+        const value = tagEl.attribs[attrName];
+        if (typeof value === 'string' && DANGEROUS_SCHEME.test(value)) {
+          $(el).removeAttr(attrName);
+        }
+      }
+    }
+  });
+
+  return $('[data-md4h-sanitize-root]').html() || '';
+}
 
 /**
  * Mermaid image data
@@ -471,6 +555,13 @@ async function exportToPDF(
   try {
     progress.report({ message: 'Launching Chrome...', increment: 20 });
 
+    // SECURITY: `--allow-file-access-from-files` was REMOVED here. Chromium
+    // documents that flag as "intended for testing only — do not use it on
+    // builds distributed to end users." Combined with markdown's `html: true`
+    // parser, it allowed a hostile .md file to embed
+    //   <script>fetch('file:///Users/<u>/.ssh/id_ed25519').then(...)</script>
+    // and exfiltrate the contents into the PDF the user just saved.
+    // See SECURITY review §H3.
     const chromeArgs = [
       '--headless=chrome',
       '--disable-gpu',
@@ -479,7 +570,6 @@ async function exportToPDF(
       '--disable-extensions',
       '--disable-software-rasterizer',
       '--disable-dev-shm-usage',
-      '--allow-file-access-from-files',
       '--print-to-pdf=' + outputPath,
       `file://${tempHtmlPath}`,
     ];
@@ -684,6 +774,10 @@ async function exportToWord(
  */
 function buildExportHTML(contentHtml: string, theme: string, _format: 'pdf' | 'html'): string {
   const styles = getExportStyles(theme);
+  // SECURITY: strip script tags, on* handlers, and javascript:/file: URIs
+  // before rendering with Chrome. See sanitizeExportHtml() docstring above
+  // and SECURITY review §H3.
+  const safeContent = sanitizeExportHtml(contentHtml);
 
   return `
     <!DOCTYPE html>
@@ -696,7 +790,7 @@ function buildExportHTML(contentHtml: string, theme: string, _format: 'pdf' | 'h
     </head>
     <body>
       <div class="content">
-        ${contentHtml}
+        ${safeContent}
       </div>
     </body>
     </html>


### PR DESCRIPTION
Fixes #39.

## Summary

Closes three high-severity issues that share a single root cause: handlers in `MarkdownEditorProvider` and `documentExport.ts` trust paths and HTML originating from attacker-controlled markdown content. Each fix lands together because they exercise the same primitive (a containment check) and a single sanitization helper.

Full threat model is in #39. This PR was written **TDD-style** — tests first (verified red), then implementation (verified green). 31 new test cases cover the new contracts.

## Files changed

| File | Lines | Why |
|---|---|---|
| `src/editor/MarkdownEditorProvider.ts` | +63, -2 | New `isPathContainedWithin` exported helper, new private `getAllowedFileRoots`, gates added to `handleRenameImage` and `handleResizeImage`. Existing `isWithinWorkspace` now delegates to the exported helper (no behavior change). |
| `src/features/documentExport.ts` | +90, -8 | New exported `sanitizeExportHtml`, called from `buildExportHTML`. Removed `--allow-file-access-from-files` from `chromeArgs`. |
| `src/__tests__/editor/pathContainment.test.ts` | new, 100 lines | 15 cases — legitimate paths, `../` traversal, prefix confusion, edge cases. |
| `src/__tests__/features/exportHtmlSanitization.test.ts` | new, 170 lines | 16 cases — `<script>`/`<iframe>`/`<object>` stripping, `on*` handlers, dangerous URI schemes, benign-markup preservation, malformed-HTML robustness. |
| `src/__tests__/editor/imageResizeInPlace.test.ts` | +60, -10 | Existing "external image" test updated to assert the new user-confirm contract; new test for the cancel path. |

## H1 — `handleRenameImage` containment check

```ts
const allowedRoots = this.getAllowedFileRoots(document);
if (!allowedRoots.some(root => isPathContainedWithin(absoluteOldPath, root))) {
  throw new Error(
    `Refusing to rename image outside the document/workspace: ${oldPath}`
  );
}
…
if (!allowedRoots.some(root => isPathContainedWithin(absoluteNewPath, root))) {
  throw new Error(
    `Refusing to rename image to a path outside the document/workspace: ${newFilename}`
  );
}
```

Both source and destination are checked. `getAllowedFileRoots` returns the workspace folder (if any), the document directory, and the image base path — de-duped.

## H2 — `handleResizeImage` containment + modal confirm

The "edit external image in place" branch is the legitimate use case for paths outside the workspace (you dropped a Desktop image, you want to resize it). Failing it closed would break that flow. Instead:

```ts
if (!insideAllowedRoot) {
  if (!absolutePathFromMessage) {
    throw new Error(`Refusing to resize image outside the document/workspace: ${imagePath}`);
  }
  const choice = await vscode.window.showWarningMessage(
    `Resize will overwrite a file outside this workspace:\n\n${absolutePath}\n\nProceed?`,
    { modal: true },
    'Overwrite'
  );
  if (choice !== 'Overwrite') {
    throw new Error('Resize cancelled by user.');
  }
}
```

The "implicit external" path (no `absolutePathFromMessage`) fails closed because that's the attack vector — it should never resolve outside the allowed roots in legitimate use. The "explicit external" path prompts.

## H3 — `sanitizeExportHtml` + drop `--allow-file-access-from-files`

The sanitizer uses cheerio (already a runtime dep — no new dependency added). Deny-list approach (rather than allow-list) so legitimate Mermaid SVGs, Tiptap-emitted class/style attrs, KaTeX output, and code-block syntax-highlight markup pass through unchanged.

```ts
$('script, iframe, object, embed, link, meta, base, form, input, …').remove();

$('*').each((_, el) => {
  for (const attrName of Object.keys(el.attribs ?? {})) {
    if (attrName.toLowerCase().startsWith('on')) $(el).removeAttr(attrName);
    if (URL_LIKE_ATTRS.has(attrName.toLowerCase())) {
      const v = el.attribs[attrName];
      if (DANGEROUS_SCHEME.test(v)) $(el).removeAttr(attrName);
    }
  }
});
```

`DANGEROUS_SCHEME = /^\s*(javascript|file|vbscript|data:text\/html)\s*:/i`. `data:image/*` is preserved (used for inlined PNGs).

The Chrome flag removal is one-line:

```diff
   '--disable-dev-shm-usage',
- '--allow-file-access-from-files',
   '--print-to-pdf=' + outputPath,
```

## Verification

Run locally on `node v24.0.1`, `npm 11.3.0`:

```
$ npx jest
Test Suites: 1 skipped, 53 passed, 53 of 54 total
Tests:       27 skipped, 121 todo, 687 passed, 835 total
```

```
$ npm run lint
> eslint src --ext ts --max-warnings 0
(clean)
```

```
$ npm run package:release
DONE  Packaged: markdown-for-humans-0.1.7.vsix (12 files, 2 MB)
```

Same file inventory as upstream `0.1.7`. Installed into Cursor 3.2.16 and VS Code 1.118.1; WYSIWYG opens existing markdown files normally, image actions still work, and an external-file resize correctly prompts for confirmation.

## Backward compatibility

- **Rename**: behavior change for paths outside the workspace — they now throw with a clear message instead of silently succeeding. Anyone deliberately using rename for sibling-directory images is unaffected (sibling dirs are inside the workspace allow-list).
- **Resize external file**: gains a one-click confirm dialog. The "edit on Desktop drag-drop" use case still works; the user just confirms once per session per file.
- **PDF export**: documents that relied on `<script>` to inject content into the export will silently lose that content. This is the intended behavior. Documents that relied on `file:///` references for inline assets will also lose them — those should be inlined as `data:` URIs, which is what the existing (commented-out) `convertImagesToDataUrls` was meant to do.

## Future work (out of scope)

- Inline local image references as `data:` URIs in `buildExportHTML` to fully decouple PDF rendering from `file://` access (the commented-out code at line 84 hints this was on the roadmap).
- Apply the same containment check to `handleOpenFileLink` (M2 in the security review) — currently lower-impact but worth fixing for parity.
- Add a `SECURITY.md` with a private reporting channel.
