### PR TITLE
Ai coding tool integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-for-humans",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-for-humans",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "MIT",
       "dependencies": {
         "@tiptap/core": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -107,6 +107,18 @@
         "command": "markdownForHumans.outline.clearFilter",
         "title": "Outline: Clear Filter",
         "icon": "$(close)"
+      },
+      {
+        "command": "markdownForHumans.copyAiContextRef",
+        "title": "Markdown for Humans: Copy AI Context Reference (@file#lines)"
+      }
+    ],
+    "keybindings": [
+      {
+        "command": "markdownForHumans.copyAiContextRef",
+        "key": "alt+c",
+        "mac": "alt+c",
+        "when": "activeCustomEditorId == 'markdownForHumans.editor'"
       }
     ],
     "views": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "markdown-for-humans",
   "displayName": "Markdown for Humans: WYSIWYG Editor",
   "description": "A full-featured WYSIWYG Markdown editor with visual table editing, drag-and-drop images, Mermaid diagrams, and distraction-free writing—all inside VS Code.",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "publisher": "concretio",
   "author": {
     "name": "Abhinav",

--- a/src/__tests__/webview/aiContextReference.realEditor.test.ts
+++ b/src/__tests__/webview/aiContextReference.realEditor.test.ts
@@ -1,0 +1,87 @@
+/** @jest-environment jsdom */
+
+/**
+ * Integration test: exercise computeSelectionBlockRange against a real TipTap
+ * editor wired up the way the production webview wires it. The standalone unit
+ * tests use stubs to verify the line math; this test exists to catch issues
+ * that only show up with the actual `@tiptap/markdown` MarkdownManager.
+ */
+
+import { Editor } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import { Markdown } from '@tiptap/markdown';
+import { ListKit } from '@tiptap/extension-list';
+import { MarkdownParagraph } from '../../webview/extensions/markdownParagraph';
+import { OrderedListMarkdownFix } from '../../webview/extensions/orderedListMarkdownFix';
+import { computeSelectionBlockRange } from '../../webview/utils/aiContextReference';
+
+function createRealEditor(initialMarkdown: string): Editor {
+  const element = document.createElement('div');
+  document.body.appendChild(element);
+  return new Editor({
+    element,
+    extensions: [
+      StarterKit.configure({
+        heading: { levels: [1, 2, 3, 4, 5, 6] },
+        paragraph: false,
+        codeBlock: false,
+        bulletList: false,
+        orderedList: false,
+        listItem: false,
+        listKeymap: false,
+        undoRedo: { depth: 100 },
+      }),
+      MarkdownParagraph,
+      Markdown.configure({
+        markedOptions: { gfm: true, breaks: true },
+      }),
+      ListKit.configure({
+        orderedList: false,
+        taskItem: { nested: true },
+      }),
+      OrderedListMarkdownFix,
+    ],
+    content: initialMarkdown,
+    contentType: 'markdown',
+  });
+}
+
+describe('computeSelectionBlockRange with a real TipTap editor', () => {
+  it('returns the first paragraph line when the cursor is in paragraph 1 of three', () => {
+    const editor = createRealEditor('First paragraph\n\nSecond paragraph\n\nThird');
+    // Place cursor inside the first paragraph.
+    editor.commands.setTextSelection(3);
+
+    const result = computeSelectionBlockRange(editor);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.range.startLine).toBe(1);
+      expect(result.range.endLine).toBe(1);
+    }
+    editor.destroy();
+  });
+
+  it('returns the third paragraph line when the cursor is in paragraph 3 of three', () => {
+    const editor = createRealEditor('First paragraph\n\nSecond paragraph\n\nThird');
+    // Move to end of doc — selection lands inside the last paragraph.
+    const docEnd = editor.state.doc.content.size;
+    editor.commands.setTextSelection(docEnd);
+
+    const result = computeSelectionBlockRange(editor);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.range.startLine).toBe(5);
+      expect(result.range.endLine).toBe(5);
+    }
+    editor.destroy();
+  });
+
+  it('reports a useful failure reason for an empty document', () => {
+    const editor = createRealEditor('');
+    const result = computeSelectionBlockRange(editor);
+    // Either empty-doc-json or no-blocks is acceptable — the actionable bit is
+    // that the result is not `ok`.
+    expect(result.ok).toBe(false);
+    editor.destroy();
+  });
+});

--- a/src/__tests__/webview/aiContextReference.test.ts
+++ b/src/__tests__/webview/aiContextReference.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Tests for aiContextReference - Copy current selection as @file#lines reference
+ *
+ * The mapping function returns the line range (in the saved markdown file) that
+ * corresponds to the top-level blocks containing the current TipTap selection.
+ */
+
+import {
+  countLines,
+  formatAiContextRef,
+  findContainingBlockIndex,
+  getSelectionBlockRange,
+} from '../../webview/utils/aiContextReference';
+
+describe('countLines', () => {
+  it('returns 0 for empty string', () => {
+    expect(countLines('')).toBe(0);
+  });
+
+  it('returns 1 for a single line without trailing newline', () => {
+    expect(countLines('abc')).toBe(1);
+  });
+
+  it('returns 1 for a single line with trailing newline', () => {
+    expect(countLines('abc\n')).toBe(1);
+  });
+
+  it('returns 2 for two lines without trailing newline', () => {
+    expect(countLines('a\nb')).toBe(2);
+  });
+
+  it('returns 2 for two lines with trailing newline', () => {
+    expect(countLines('a\nb\n')).toBe(2);
+  });
+
+  it('returns 3 for three lines', () => {
+    expect(countLines('a\nb\nc')).toBe(3);
+  });
+
+  it('counts blank lines correctly', () => {
+    // "a\n\nb" is "a", "", "b" — 3 lines
+    expect(countLines('a\n\nb')).toBe(3);
+  });
+});
+
+describe('formatAiContextRef', () => {
+  it('formats a single-line reference as #N (no range)', () => {
+    expect(formatAiContextRef('src/foo.md', 42, 42)).toBe('@src/foo.md#42');
+  });
+
+  it('formats a multi-line range as #N-M', () => {
+    expect(formatAiContextRef('src/foo.md', 42, 58)).toBe('@src/foo.md#42-58');
+  });
+
+  it('preserves nested workspace-relative paths', () => {
+    expect(formatAiContextRef('docs/guide/intro.md', 1, 10)).toBe('@docs/guide/intro.md#1-10');
+  });
+
+  it('does not collapse a true range when start === end - 0 (sanity)', () => {
+    expect(formatAiContextRef('a.md', 5, 6)).toBe('@a.md#5-6');
+  });
+});
+
+describe('findContainingBlockIndex', () => {
+  const blocks = [
+    { from: 1, to: 6 }, // block 0
+    { from: 6, to: 13 }, // block 1
+    { from: 13, to: 21 }, // block 2
+  ];
+
+  it('finds the first block', () => {
+    expect(findContainingBlockIndex(blocks, 3)).toBe(0);
+  });
+
+  it('finds the middle block', () => {
+    expect(findContainingBlockIndex(blocks, 9)).toBe(1);
+  });
+
+  it('finds the last block', () => {
+    expect(findContainingBlockIndex(blocks, 18)).toBe(2);
+  });
+
+  it('treats a position exactly at a block boundary as the next block', () => {
+    // pos == 6 is end-of-block-0 / start-of-block-1; should belong to block 1
+    expect(findContainingBlockIndex(blocks, 6)).toBe(1);
+  });
+
+  it('clamps a position past the last block to the last block (gap cursor case)', () => {
+    expect(findContainingBlockIndex(blocks, 999)).toBe(2);
+  });
+
+  it('returns -1 for an empty block list', () => {
+    expect(findContainingBlockIndex([], 5)).toBe(-1);
+  });
+});
+
+// Build a minimal stub editor that mimics the bits getSelectionBlockRange touches.
+// We intentionally avoid pulling in real TipTap because:
+//   - we are unit-testing the position->line math, not TipTap itself;
+//   - the existing repo pattern (see copyMarkdown.test.ts) explicitly skips real-editor
+//     integration tests for this layer.
+type StubBlockNode = {
+  typeName: string;
+  nodeSize: number;
+  text?: string; // for empty-paragraph detection
+};
+
+function buildStubEditor(opts: {
+  blocks: StubBlockNode[];
+  selection: { from: number; to: number; empty: boolean };
+  // serialize(json) returns the string the on-disk file would contain
+  serialize: (json: { type: string; content: unknown[] }) => string;
+  jsonContent?: unknown[]; // if omitted, derived from blocks.text
+}) {
+  const jsonContent =
+    opts.jsonContent ??
+    opts.blocks.map(b => {
+      if (b.typeName === 'paragraph') {
+        const text = b.text ?? '';
+        return text.length === 0
+          ? { type: 'paragraph' }
+          : { type: 'paragraph', content: [{ type: 'text', text }] };
+      }
+      return { type: b.typeName, content: [{ type: 'text', text: b.text ?? '' }] };
+    });
+
+  const fragment = {
+    forEach(cb: (node: unknown, offset: number, idx: number) => void) {
+      let offset = 0;
+      opts.blocks.forEach((b, idx) => {
+        const node = {
+          type: { name: b.typeName },
+          nodeSize: b.nodeSize,
+          content: {
+            size: (b.text ?? '').length,
+            forEach(childCb: (child: unknown) => void) {
+              const t = b.text ?? '';
+              if (t.length > 0) childCb({ type: { name: 'text' }, text: t });
+            },
+          },
+        };
+        cb(node, offset, idx);
+        offset += b.nodeSize;
+      });
+    },
+  };
+
+  return {
+    state: {
+      selection: opts.selection,
+      doc: { content: fragment },
+    },
+    getJSON: () => ({ type: 'doc', content: jsonContent }),
+    markdown: { serialize: opts.serialize },
+  };
+}
+
+describe('getSelectionBlockRange', () => {
+  it('returns null for an empty document', () => {
+    const editor = buildStubEditor({
+      blocks: [],
+      selection: { from: 0, to: 0, empty: true },
+      serialize: () => '',
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(getSelectionBlockRange(editor as any)).toBeNull();
+  });
+
+  it('returns null when the markdown serializer is unavailable', () => {
+    const editor = {
+      state: {
+        selection: { from: 1, to: 1, empty: true },
+        doc: { content: { forEach: () => {} } },
+      },
+      getJSON: () => ({ type: 'doc', content: [{ type: 'paragraph' }] }),
+      // no markdown manager
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(getSelectionBlockRange(editor as any)).toBeNull();
+  });
+
+  it('returns #1 for a cursor inside the first paragraph of a single-paragraph doc', () => {
+    // Doc serializes to "Hello world\n" — 1 line.
+    const editor = buildStubEditor({
+      blocks: [{ typeName: 'paragraph', text: 'Hello world', nodeSize: 13 }],
+      selection: { from: 4, to: 4, empty: true },
+      serialize: json => (json.content.length === 0 ? '' : 'Hello world\n'),
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(getSelectionBlockRange(editor as any)).toEqual({ startLine: 1, endLine: 1 });
+  });
+
+  it('returns the line range for a selection spanning paragraph 1 to paragraph 2', () => {
+    // Three paragraphs. Markdown form (paragraph + blank + paragraph + blank + paragraph + final \n):
+    //   line 1: "First paragraph"
+    //   line 2: ""
+    //   line 3: "Second paragraph"
+    //   line 4: ""
+    //   line 5: "Third"
+    //   (trailing newline)
+    // Selection covers blocks 0 and 1 -> startLine 1, endLine 3.
+    const blocks = [
+      { typeName: 'paragraph', text: 'First paragraph', nodeSize: 17 },
+      { typeName: 'paragraph', text: 'Second paragraph', nodeSize: 18 },
+      { typeName: 'paragraph', text: 'Third', nodeSize: 7 },
+    ];
+    const editor = buildStubEditor({
+      blocks,
+      // selection starts mid-block-0, ends mid-block-1
+      selection: { from: 5, to: 25, empty: false },
+      serialize: json => {
+        // Render each paragraph as text, separated by blank lines, with trailing \n.
+        const texts = (json.content as Array<{ content?: Array<{ text: string }> }>).map(
+          p => p.content?.[0]?.text ?? ''
+        );
+        return texts.length === 0 ? '' : texts.join('\n\n') + '\n';
+      },
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(getSelectionBlockRange(editor as any)).toEqual({ startLine: 1, endLine: 3 });
+  });
+
+  it('returns the correct range when the selection is entirely inside the third block', () => {
+    // Same three paragraphs as above.
+    // Block 2 spans lines 5..5.
+    const blocks = [
+      { typeName: 'paragraph', text: 'First paragraph', nodeSize: 17 },
+      { typeName: 'paragraph', text: 'Second paragraph', nodeSize: 18 },
+      { typeName: 'paragraph', text: 'Third', nodeSize: 7 },
+    ];
+    const editor = buildStubEditor({
+      blocks,
+      selection: { from: 36, to: 38, empty: false }, // inside block 2
+      serialize: json => {
+        const texts = (json.content as Array<{ content?: Array<{ text: string }> }>).map(
+          p => p.content?.[0]?.text ?? ''
+        );
+        return texts.length === 0 ? '' : texts.join('\n\n') + '\n';
+      },
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(getSelectionBlockRange(editor as any)).toEqual({ startLine: 5, endLine: 5 });
+  });
+
+  it('returns the full block range when the cursor (empty selection) sits on a multi-line code block', () => {
+    // Doc is a single fenced code block of three content lines:
+    //   line 1: "```js"
+    //   line 2: "const x = 1;"
+    //   line 3: "const y = 2;"
+    //   line 4: "```"
+    //   (trailing newline)
+    const blocks = [{ typeName: 'codeBlock', text: 'const x = 1;\nconst y = 2;', nodeSize: 27 }];
+    const editor = buildStubEditor({
+      blocks,
+      selection: { from: 5, to: 5, empty: true },
+      serialize: json =>
+        json.content.length === 0 ? '' : '```js\nconst x = 1;\nconst y = 2;\n```\n',
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(getSelectionBlockRange(editor as any)).toEqual({ startLine: 1, endLine: 4 });
+  });
+
+  it('skips empty leading paragraphs when computing the start line', () => {
+    // The editor has an empty paragraph at the top that the save pipeline will strip
+    // (stripEmptyDocParagraphsFromJson). The serialized file therefore starts at the
+    // second editor block, which should map to line 1, not line 3.
+    const blocks = [
+      { typeName: 'paragraph', text: '', nodeSize: 2 }, // will be stripped
+      { typeName: 'paragraph', text: 'Real first paragraph', nodeSize: 22 },
+      { typeName: 'paragraph', text: 'Second', nodeSize: 8 },
+    ];
+    const editor = buildStubEditor({
+      blocks,
+      selection: { from: 5, to: 5, empty: true }, // inside the "Real first paragraph"
+      serialize: json => {
+        const texts = (json.content as Array<{ content?: Array<{ text: string }> }>)
+          .filter(p => p.content && p.content.length > 0)
+          .map(p => p.content?.[0]?.text ?? '');
+        return texts.length === 0 ? '' : texts.join('\n\n') + '\n';
+      },
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(getSelectionBlockRange(editor as any)).toEqual({ startLine: 1, endLine: 1 });
+  });
+});

--- a/src/editor/MarkdownEditorProvider.ts
+++ b/src/editor/MarkdownEditorProvider.ts
@@ -639,6 +639,63 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
       case 'auditPickFile':
         void this.handleAuditPickFile(message, document, webview);
         break;
+      case 'getAiContextRef':
+        void this.handleGetAiContextRef(message, document, webview);
+        break;
+    }
+  }
+
+  /**
+   * Build a Claude-Code-style `@file#startLine-endLine` reference for the active
+   * document. Saves the document first so the line numbers the webview just
+   * computed match the bytes on disk that an AI tool will read.
+   *
+   * Path is workspace-relative (POSIX separators) when the file is inside an
+   * open workspace folder. Files outside any workspace fall back to the absolute
+   * fsPath, also normalized to forward slashes.
+   */
+  private async handleGetAiContextRef(
+    message: { type: string; [key: string]: unknown },
+    document: vscode.TextDocument,
+    webview: vscode.Webview
+  ): Promise<void> {
+    const requestId = message.requestId as string;
+    const startLine = message.startLine as number;
+    const endLine = message.endLine as number;
+
+    const reply = (payload: { ref?: string; relPath?: string; error?: string }) => {
+      webview.postMessage({
+        type: 'aiContextRefResponse',
+        requestId,
+        ...payload,
+      });
+    };
+
+    if (typeof requestId !== 'string') return;
+    if (typeof startLine !== 'number' || typeof endLine !== 'number') {
+      reply({ error: 'Invalid line range' });
+      return;
+    }
+
+    try {
+      if (document.isDirty) {
+        const saved = await document.save();
+        if (!saved) {
+          reply({ error: 'Could not save document before copying reference' });
+          return;
+        }
+      }
+
+      const filePath = document.uri.fsPath;
+      const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
+      const relRaw = workspaceFolder
+        ? path.relative(workspaceFolder.uri.fsPath, filePath)
+        : filePath;
+      const relPath = relRaw.replace(/\\/g, '/');
+      const suffix = startLine === endLine ? `#${startLine}` : `#${startLine}-${endLine}`;
+      reply({ ref: `@${relPath}${suffix}`, relPath });
+    } catch (error) {
+      reply({ error: error instanceof Error ? error.message : String(error) });
     }
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -130,6 +130,18 @@ export function activate(context: vscode.ExtensionContext) {
       outlineViewProvider.clearFilter();
     })
   );
+
+  // Forward the keybinding to the active webview, which runs the same code path
+  // as the toolbar button. The webview owns the selection state, so the host
+  // command stays a thin trigger.
+  context.subscriptions.push(
+    vscode.commands.registerCommand('markdownForHumans.copyAiContextRef', () => {
+      const panel = getActiveWebviewPanel();
+      if (panel) {
+        panel.webview.postMessage({ type: 'triggerCopyAiContextRef' });
+      }
+    })
+  );
 }
 
 export function deactivate() {

--- a/src/webview/BubbleMenuView.ts
+++ b/src/webview/BubbleMenuView.ts
@@ -595,6 +595,17 @@ export function createFormattingToolbar(editor: Editor): HTMLElement {
       className: 'copy-button',
     },
     {
+      type: 'button',
+      label: 'Copy AI Ref',
+      title: 'Copy as AI Context',
+      icon: { name: 'mention', fallback: '@' },
+      action: () => {
+        window.dispatchEvent(new CustomEvent('copyAiContextRef'));
+      },
+      isActive: () => false,
+      className: 'copy-ai-ref-button',
+    },
+    {
       type: 'dropdown',
       label: 'Export',
       title: 'Export document',

--- a/src/webview/BubbleMenuView.ts
+++ b/src/webview/BubbleMenuView.ts
@@ -598,7 +598,7 @@ export function createFormattingToolbar(editor: Editor): HTMLElement {
       type: 'button',
       label: 'Copy AI Ref',
       title: 'Copy as AI Context',
-      icon: { name: 'mention', fallback: '@' },
+      icon: { name: 'sparkle', fallback: '✨' },
       action: () => {
         window.dispatchEvent(new CustomEvent('copyAiContextRef'));
       },

--- a/src/webview/editor.ts
+++ b/src/webview/editor.ts
@@ -39,6 +39,7 @@ import { toggleSearchOverlay } from './features/searchOverlay';
 import { showLinkDialog } from './features/linkDialog';
 import { processPasteContent, parseFencedCode } from './utils/pasteHandler';
 import { copySelectionAsMarkdown } from './utils/copyMarkdown';
+import { copyAiContextReference, type SelectionBlockRange } from './utils/aiContextReference';
 import { shouldAutoLink } from './utils/linkValidation';
 import { buildOutlineFromEditor } from './utils/outline';
 import { scrollToHeading } from './utils/scrollToHeading';
@@ -209,6 +210,35 @@ const scheduleOutlineUpdate = () => {
     outlineUpdateTimeout = null;
   }, OUTLINE_UPDATE_DEBOUNCE_MS);
 };
+
+// Pending AI context reference requests, keyed by requestId. The host saves the
+// document and replies with `aiContextRefResponse`; we look up the resolver here.
+const aiContextRefCallbacks = new Map<
+  string,
+  (response: { ref?: string; relPath?: string; error?: string }) => void
+>();
+
+async function runCopyAiContextRef(): Promise<void> {
+  if (!editor) return;
+  const { showToast } = await import('./features/auditOverlay');
+  const result = await copyAiContextReference(editor, (range: SelectionBlockRange) => {
+    return new Promise(resolve => {
+      const requestId = `ai-ref-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+      aiContextRefCallbacks.set(requestId, resolve);
+      vscode.postMessage({
+        type: 'getAiContextRef',
+        requestId,
+        startLine: range.startLine,
+        endLine: range.endLine,
+      });
+    });
+  });
+  if (result.success) {
+    showToast(`Copied AI reference: ${result.ref}`, 'success');
+  } else {
+    showToast(result.error || 'Could not copy AI reference', 'info');
+  }
+}
 
 // Global function for resolving image paths (used by CustomImage extension)
 const uriResolveCallbacks = new Map<string, (uri: string) => void>();
@@ -715,6 +745,18 @@ function initializeEditor(initialContent: string) {
         if (editor) {
           toggleSearchOverlay(editor);
         }
+        return;
+      }
+
+      // Cmd/Ctrl+Alt+C — Copy current selection as @file#lines AI context reference.
+      // VS Code keybindings declared in package.json don't fire while focus is
+      // inside a webview iframe, so we have to detect the chord here ourselves.
+      // Match e.code instead of e.key because Ctrl+Alt on Windows is the AltGr
+      // modifier on some layouts and can rewrite e.key to a non-letter glyph.
+      if (isMod && e.altKey && (e.code === 'KeyC' || e.key.toLowerCase() === 'c')) {
+        e.preventDefault();
+        e.stopPropagation();
+        void runCopyAiContextRef();
         return;
       }
     };
@@ -1296,6 +1338,23 @@ window.addEventListener('message', (event: MessageEvent) => {
         }
         break;
       }
+      case 'aiContextRefResponse': {
+        const requestId = message.requestId as string;
+        const callback = aiContextRefCallbacks.get(requestId);
+        if (callback) {
+          callback({
+            ref: message.ref as string | undefined,
+            relPath: message.relPath as string | undefined,
+            error: message.error as string | undefined,
+          });
+          aiContextRefCallbacks.delete(requestId);
+        }
+        break;
+      }
+      case 'triggerCopyAiContextRef': {
+        void runCopyAiContextRef();
+        break;
+      }
       case 'navigateToHeading': {
         if (!editor) return;
         const pos = message.pos as number;
@@ -1508,6 +1567,11 @@ window.addEventListener('auditDocument', async () => {
 window.addEventListener('copyAsMarkdown', () => {
   if (!editor) return;
   copySelectionAsMarkdown(editor);
+});
+
+// Handle copy AI context reference from toolbar button
+window.addEventListener('copyAiContextRef', () => {
+  void runCopyAiContextRef();
 });
 
 // Handle open source view from toolbar button

--- a/src/webview/utils/aiContextReference.ts
+++ b/src/webview/utils/aiContextReference.ts
@@ -1,0 +1,288 @@
+/**
+ * Copyright (c) 2025-2026 Concret.io
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for details.
+ *
+ * @fileoverview Build a Claude-Code-style `@file#startLine-endLine` reference for the
+ * current TipTap selection so the user can paste precise context into AI coding tools.
+ *
+ * The math is block-rounded: a partial selection inside a paragraph reports the
+ * paragraph's full line range. This is intentional — AI tools want enough context
+ * to understand the surrounding text, not arbitrary half-blocks.
+ *
+ * Path resolution and the auto-save-before-copy step are handled by the extension
+ * host; this module only computes line numbers and formats the final string.
+ */
+
+import type { Editor, JSONContent } from '@tiptap/core';
+import { stripEmptyDocParagraphsFromJson } from './markdownSerialization';
+import { copyToClipboard } from './copyMarkdown';
+
+export interface AiContextRefResult {
+  success: boolean;
+  ref?: string;
+  error?: string;
+}
+
+export interface SelectionBlockRange {
+  startLine: number;
+  endLine: number;
+}
+
+interface BlockPos {
+  from: number;
+  to: number;
+}
+
+type MarkdownManager = {
+  serialize?: (json: JSONContent) => string;
+};
+
+/**
+ * Count the number of lines a string represents.
+ *
+ * Matches the natural reading: "abc" is 1 line, "a\nb" is 2, "a\nb\n" is also 2
+ * (a trailing newline does not add a line). Empty string is 0 lines.
+ */
+export function countLines(s: string): number {
+  if (s.length === 0) return 0;
+  let count = 0;
+  for (let i = 0; i < s.length; i++) {
+    if (s[i] === '\n') count++;
+  }
+  if (s[s.length - 1] !== '\n') count++;
+  return count;
+}
+
+/**
+ * Format the final clipboard string.
+ * Single-line selections collapse to `#42`; multi-line use `#42-58`.
+ */
+export function formatAiContextRef(relPath: string, startLine: number, endLine: number): string {
+  const suffix = startLine === endLine ? `#${startLine}` : `#${startLine}-${endLine}`;
+  return `@${relPath}${suffix}`;
+}
+
+/**
+ * Find the index of the block that contains a given ProseMirror document position.
+ *
+ * A position exactly at a block boundary (`pos === block.to`) is treated as
+ * belonging to the next block, matching how a cursor at end-of-paragraph behaves.
+ * Positions past the last block clamp to the last block (gap-cursor case).
+ */
+export function findContainingBlockIndex(blocks: BlockPos[], pos: number): number {
+  if (blocks.length === 0) return -1;
+  for (let i = 0; i < blocks.length; i++) {
+    if (pos < blocks[i].to) return i;
+  }
+  return blocks.length - 1;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function isEmptyParagraphNode(node: any): boolean {
+  if (!node || !node.type || node.type.name !== 'paragraph') return false;
+  const content = node.content;
+  if (!content || content.size === 0) return true;
+  let hasMeaningful = false;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  content.forEach((child: any) => {
+    if (!child || !child.type) return;
+    const name = child.type.name;
+    if (name === 'hardBreak' || name === 'hard_break') return;
+    if (name === 'text') {
+      const text = typeof child.text === 'string' ? child.text : '';
+      if (text.trim().length > 0) hasMeaningful = true;
+      return;
+    }
+    hasMeaningful = true;
+  });
+  return !hasMeaningful;
+}
+
+/**
+ * Compute the line range (in the saved markdown file) that the current selection
+ * covers, rounded out to whole top-level blocks.
+ *
+ * Returns null when:
+ *   - the doc has no content,
+ *   - the markdown serializer is unavailable,
+ *   - the selection cannot be mapped to any non-empty block.
+ *
+ * The caller is expected to have just auto-saved the document, so the file on
+ * disk is exactly `serialize(stripEmptyDocParagraphsFromJson(getJSON()))`. The
+ * returned line numbers reference that file.
+ */
+export type SelectionBlockRangeFailure =
+  | 'no-serializer'
+  | 'no-getJSON'
+  | 'empty-doc-json'
+  | 'no-blocks'
+  | 'selection-out-of-range'
+  | 'index-mismatch'
+  | 'serializer-threw';
+
+export type SelectionBlockRangeResult =
+  | { ok: true; range: SelectionBlockRange }
+  | { ok: false; reason: SelectionBlockRangeFailure; detail?: string };
+
+/**
+ * Internal variant that returns a structured failure reason. Useful for surfacing
+ * actionable error messages and console diagnostics; the public wrapper below
+ * reduces this to `SelectionBlockRange | null` for backwards-compat with tests.
+ */
+export function computeSelectionBlockRange(editor: Editor): SelectionBlockRangeResult {
+  const { from, to, empty } = editor.state.selection;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const editorAny = editor as any;
+  const direct: MarkdownManager | undefined = editorAny.markdown;
+  // editor.storage.markdown is `{ manager: MarkdownManager }` in @tiptap/markdown >=3,
+  // not a manager itself, so unwrap `.manager` when falling back.
+  const fromStorage: MarkdownManager | undefined = editorAny.storage?.markdown?.manager;
+  const markdownManager: MarkdownManager | undefined = direct ?? fromStorage;
+  const serialize = markdownManager?.serialize?.bind(markdownManager);
+  if (typeof serialize !== 'function') {
+    return { ok: false, reason: 'no-serializer' };
+  }
+  if (typeof editor.getJSON !== 'function') {
+    return { ok: false, reason: 'no-getJSON' };
+  }
+
+  const docJson = stripEmptyDocParagraphsFromJson(editor.getJSON());
+  if (!Array.isArray(docJson.content) || docJson.content.length === 0) {
+    return { ok: false, reason: 'empty-doc-json' };
+  }
+
+  // Walk the live editor doc to learn each top-level block's PM position range.
+  // Skip blocks that the save pipeline strips (empty paragraphs) so the indices
+  // we compute line up with `docJson.content`.
+  const blocks: BlockPos[] = [];
+  let blockCount = 0;
+  // ProseMirror's doc-level fragment offsets are 0-based within the fragment.
+  // Top-level child positions in the doc are `offset + 1` because the doc node
+  // itself contributes a leading position.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  editor.state.doc.content.forEach((node: any, offset: number) => {
+    blockCount++;
+    if (isEmptyParagraphNode(node)) return;
+    blocks.push({
+      from: offset + 1,
+      to: offset + 1 + node.nodeSize,
+    });
+  });
+  if (blockCount === 0 || blocks.length === 0) {
+    return {
+      ok: false,
+      reason: 'no-blocks',
+      detail: `blockCount=${blockCount} blocks.length=${blocks.length}`,
+    };
+  }
+
+  const startIdx = findContainingBlockIndex(blocks, from);
+  const endIdx = empty ? startIdx : findContainingBlockIndex(blocks, to);
+  if (startIdx < 0 || endIdx < 0) {
+    return {
+      ok: false,
+      reason: 'selection-out-of-range',
+      detail: `from=${from} to=${to} blocks=${blocks.length}`,
+    };
+  }
+  if (startIdx >= docJson.content.length || endIdx >= docJson.content.length) {
+    return {
+      ok: false,
+      reason: 'index-mismatch',
+      detail: `startIdx=${startIdx} endIdx=${endIdx} jsonLen=${docJson.content.length} blocks=${blocks.length}`,
+    };
+  }
+
+  const prefix: JSONContent = {
+    type: 'doc',
+    content: docJson.content.slice(0, startIdx),
+  };
+  const through: JSONContent = {
+    type: 'doc',
+    content: docJson.content.slice(0, endIdx + 1),
+  };
+
+  let prefixSerialized = '';
+  let throughSerialized = '';
+  try {
+    prefixSerialized = serialize(prefix);
+    throughSerialized = serialize(through);
+  } catch (err) {
+    return {
+      ok: false,
+      reason: 'serializer-threw',
+      detail: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  // Standard markdown serialization separates top-level blocks with a single
+  // blank line and ends with a trailing newline. So the block following a
+  // non-empty prefix begins exactly two lines after the prefix's last line:
+  // one blank-line separator, plus the block's first textual line.
+  // When startIdx === 0, there is no prefix and the first block starts at line 1.
+  const startLine = startIdx === 0 ? 1 : countLines(prefixSerialized) + 2;
+  const endLine = Math.max(startLine, countLines(throughSerialized));
+
+  return { ok: true, range: { startLine, endLine } };
+}
+
+export function getSelectionBlockRange(editor: Editor): SelectionBlockRange | null {
+  const result = computeSelectionBlockRange(editor);
+  return result.ok ? result.range : null;
+}
+
+/**
+ * High-level orchestration used by both the toolbar button and the keybinding:
+ *   1. Compute the selection's block-rounded line range.
+ *   2. Ask the extension host to save the document and return a workspace-relative
+ *      path (so the file on disk matches the line numbers we just computed).
+ *   3. Format `@path#startLine-endLine` and write it to the clipboard.
+ *
+ * The host round-trip is abstracted behind `requestPathFromHost` so the function
+ * can be exercised without a real `vscode` webview API in tests if needed later.
+ */
+export async function copyAiContextReference(
+  editor: Editor,
+  requestPathFromHost: (
+    range: SelectionBlockRange
+  ) => Promise<{ ref?: string; relPath?: string; error?: string }>
+): Promise<AiContextRefResult> {
+  const result = computeSelectionBlockRange(editor);
+  if (!result.ok) {
+    const message = result.detail
+      ? `AI ref unavailable (${result.reason}: ${result.detail})`
+      : `AI ref unavailable (${result.reason})`;
+    // Surface to the dev console so the user can grab the exact reason if the
+    // toast text is truncated. Keeps host/webview separation — no PII leaves the box.
+    console.warn('[MD4H][aiContextRef]', result);
+    return { success: false, error: message };
+  }
+  const range = result.range;
+
+  let response: { ref?: string; relPath?: string; error?: string };
+  try {
+    response = await requestPathFromHost(range);
+  } catch (err) {
+    return { success: false, error: String(err) };
+  }
+  if (response.error) {
+    return { success: false, error: response.error };
+  }
+
+  const ref =
+    response.ref ??
+    (response.relPath
+      ? formatAiContextRef(response.relPath, range.startLine, range.endLine)
+      : undefined);
+  if (!ref) {
+    return { success: false, error: 'Host did not return a path' };
+  }
+
+  const copyResult = await copyToClipboard(ref);
+  if (!copyResult.success) {
+    return { success: false, error: copyResult.error };
+  }
+  return { success: true, ref };
+}


### PR DESCRIPTION
## Summary

This PR introduces a **"Copy as AI Context"** feature to improve developer workflow when referencing content from the editor in AI tools such as Claude Code or Cursor.

## What’s Included

- A new toolbar button and keybinding.
- Conversion of the current cursor position or text selection into a structured `@file#line` reference
- Automatic copying of the formatted reference to the clipboard

## How It Works

1. The user places the cursor or selects a range of text within the editor  
2. The user clicks the **"Copy as AI Context"** button or triggers the keybinding  
3. The extension host resolves the corresponding line numbers in the underlying `.md` file  
4. The selection is formatted as:
@/path/to/file.md#L32-38