### PR TITLE
Updated when clause

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,6 +138,13 @@
           "group": "navigation"
         }
       ],
+      "editor/title/context": [
+        {
+          "command": "markdownForHumans.openFile",
+          "when": "resourceExtname == .md && activeCustomEditorId != 'markdownForHumans.editor'",
+          "group": "navigation"
+        }
+      ],
       "view/title": [
         {
           "command": "markdownForHumans.outline.revealCurrent",


### PR DESCRIPTION
## Enhanced the `when` clause for the menu option to open files. The option will now only be shown when the file is not already opened with Markdown for Humans.