### PR TITLE
feat: editor theme override (Display: Editor Theme setting + toolbar toggle)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### Editor Theme Override
 Choose the editor's color theme independently of the rest of VS Code:
-- New `markdownForHumans.display.editorTheme` setting: Follow VS Code theme (default), Always use the default light theme, or Always use the default dark theme
-- A light/dark toggle button at the end of the editor toolbar flips between the fixed light and dark themes and applies to all open editors
-- Forced themes use self-contained Light/Dark Modern palettes, so the editor surface stays light (or dark) even when VS Code is set to the opposite theme
+- New `markdownForHumans.display.editorTheme` setting: Follow VS Code theme (default), Always use a light theme, or Always use a dark theme
+- A light/dark toggle button at the end of the editor toolbar flips between light and dark and applies to all open editors
+- When your active VS Code theme already matches the chosen appearance the editor uses that real theme; when forcing the opposite (for example a light editor while VS Code is dark) it falls back to a built-in light or dark theme
+- The forced appearance follows VS Code live: switching your VS Code theme re-evaluates the editor automatically
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### What's New
+
+#### Editor Theme Override
+Choose the editor's color theme independently of the rest of VS Code:
+- New `markdownForHumans.display.editorTheme` setting: Follow VS Code theme (default), Always use the default light theme, or Always use the default dark theme
+- A light/dark toggle button at the end of the editor toolbar flips between the fixed light and dark themes and applies to all open editors
+- Forced themes use self-contained Light/Dark Modern palettes, so the editor surface stays light (or dark) even when VS Code is set to the opposite theme
+
 ---
 
 ## [0.2.1] - 2026-05-19

--- a/README.md
+++ b/README.md
@@ -173,8 +173,8 @@ Customize the editor behavior through VS Code settings. Access via `Ctrl+,` (Set
 - **`markdownForHumans.display.editorTheme`** (default: `"vscode"`)
   - Controls the editor's color theme independently of the rest of VS Code.
   - `Follow VS Code theme` mirrors your active VS Code theme (default).
-  - `Always use the default light theme` / `Always use the default dark theme` render the editor in a fixed light or dark theme regardless of VS Code.
-  - The light/dark toggle button at the end of the editor toolbar switches between the fixed light and dark themes and applies to all open editors.
+  - `Always use a light theme` / `Always use a dark theme` keep the editor light or dark regardless of VS Code. When your active VS Code theme already matches the chosen appearance the editor uses that real theme; otherwise it falls back to a built-in light or dark theme.
+  - The light/dark toggle button at the end of the editor toolbar switches between light and dark and applies to all open editors.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,14 @@ Customize the editor behavior through VS Code settings. Access via `Ctrl+,` (Set
 - **`markdownForHumans.chromePath`** (default: `""`)
   - Path to Google Chrome or Chromium executable for PDF export. Leave empty to auto-detect.
 
+### Display Settings
+
+- **`markdownForHumans.display.editorTheme`** (default: `"vscode"`)
+  - Controls the editor's color theme independently of the rest of VS Code.
+  - `Follow VS Code theme` mirrors your active VS Code theme (default).
+  - `Always use the default light theme` / `Always use the default dark theme` render the editor in a fixed light or dark theme regardless of VS Code.
+  - The light/dark toggle button at the end of the editor toolbar switches between the fixed light and dark themes and applies to all open editors.
+
 ---
 
 ## More Features

--- a/package.json
+++ b/package.json
@@ -233,6 +233,22 @@
           "maximum": 200,
           "description": "Zoom level for the editor as a percentage. 100 = default size, 150 = 50% larger, etc.",
           "scope": "application"
+        },
+        "markdownForHumans.display.editorTheme": {
+          "type": "string",
+          "enum": [
+            "vscode",
+            "defaultLight",
+            "defaultDark"
+          ],
+          "enumDescriptions": [
+            "Follow VS Code theme",
+            "Always use the default light theme",
+            "Always use the default dark theme"
+          ],
+          "default": "vscode",
+          "description": "Controls the editor's color theme. 'Follow VS Code theme' mirrors your active VS Code theme; the other options render the editor in a fixed light or dark theme regardless of VS Code. The toolbar theme toggle switches between the fixed light and dark themes and applies to all open editors.",
+          "scope": "application"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -243,11 +243,11 @@
           ],
           "enumDescriptions": [
             "Follow VS Code theme",
-            "Always use the default light theme",
-            "Always use the default dark theme"
+            "Always use a light theme",
+            "Always use a dark theme"
           ],
           "default": "vscode",
-          "description": "Controls the editor's color theme. 'Follow VS Code theme' mirrors your active VS Code theme; the other options render the editor in a fixed light or dark theme regardless of VS Code. The toolbar theme toggle switches between the fixed light and dark themes and applies to all open editors.",
+          "description": "Controls the editor's color theme. 'Follow VS Code theme' mirrors your active VS Code theme. 'Always light'/'Always dark' keep the editor light or dark regardless of VS Code: when VS Code's theme already matches that appearance the editor uses your real theme, otherwise it falls back to a built-in light/dark theme. The toolbar toggle switches between light and dark and applies to all open editors.",
           "scope": "application"
         }
       }

--- a/roadmap/pipeline/task-editor-theme-override.md
+++ b/roadmap/pipeline/task-editor-theme-override.md
@@ -56,7 +56,7 @@
 
 **Entry points:**
 - Settings UI: `Markdown for Humans > Display: Editor Theme`.
-- Toolbar: a `color-mode` (half-filled circle) button near the gear/settings button.
+- Toolbar: a `color-mode` (half-filled circle) button placed at the end of the toolbar, immediately to the right of the gear/settings button.
 
 **User flows:**
 
@@ -90,7 +90,7 @@
 - `package.json` - add `markdownForHumans.display.editorTheme` enum under `contributes.configuration` (with `enumDescriptions`, `scope: application`).
 - `src/editor/MarkdownEditorProvider.ts` - read `editorTheme`, include it in the `update`, `ready`, and `settingsUpdate` payloads; extend `onDidChangeConfiguration` to watch `markdownForHumans.display.editorTheme`; add a `toggleTheme` message handler that calls a pure resolver and writes opposite value to global config.
 - `src/editor/themeResolver.ts` (new) - pure function `resolveToggleTarget(setting, vscodeKind) => 'defaultLight' | 'defaultDark'` so it is unit-testable without VS Code.
-- `src/webview/BubbleMenuView.ts` - add the `color-mode` toggle button (posts `{type:'toggleTheme'}`).
+- `src/webview/BubbleMenuView.ts` - add the `color-mode` toggle button as the last entry in the `buttons` array, after the `settings-button` gear (posts `{type:'toggleTheme'}`).
 - `src/webview/editor.ts` - handle `editorTheme` in `update`/`settingsUpdate`; add `applyThemeOverride(mode)` next to `applyEditorSettings()` to set/clear `mdfh-force-light`/`mdfh-force-dark` on `document.body`.
 - `src/webview/editor.css` - define `.mdfh-force-light` and `.mdfh-force-dark` blocks that override the `--vscode-*` variables the editor consumes (editor bg/fg, widget bg/border, button bg/fg, link, code bg, panel border, list hover, focus border); add `.mdfh-force-dark` as a sibling selector to the existing `.vscode-dark` syntax-highlight rules.
 

--- a/roadmap/pipeline/task-editor-theme-override.md
+++ b/roadmap/pipeline/task-editor-theme-override.md
@@ -4,7 +4,7 @@
 
 - **Task name:** Editor Theme Override
 - **Slug:** editor-theme-override
-- **Status:** planned
+- **Status:** in-progress
 - **Created:** 2026-05-26
 - **Last updated:** 2026-05-26
 - **Shipped:** _(pending)_
@@ -129,7 +129,24 @@
 
 ## 7. Implementation Log
 
-_(Fill in as you implement.)_
+### 2026-05-26 - Feature implemented (TDD)
+
+- **What:** Built the setting, toolbar toggle, and forced palettes end to end.
+- **Files:**
+  - `src/shared/editorTheme.ts` (new) - pure helpers `appearanceFromKind`, `effectiveAppearance`, `resolveToggleTarget`, `forcedThemeClass`.
+  - `src/__tests__/editor/editorTheme.test.ts` (new) - 15 unit tests (written first; watched red then green).
+  - `package.json` - `markdownForHumans.display.editorTheme` enum (scope: application).
+  - `src/editor/MarkdownEditorProvider.ts` - `getEditorTheme()`, `editorTheme` in update/ready/settingsUpdate payloads, config watch, `toggleTheme` -> `handleToggleTheme()` writing the opposite to global config.
+  - `src/webview/BubbleMenuView.ts` - `color-mode` toggle button after the gear.
+  - `src/webview/editor.ts` - `toggleTheme` event bridge + `applyThemeOverride()` wired into `applyEditorSettings`.
+  - `src/webview/editor.css` - `.mdfh-force-light` / `.mdfh-force-dark` palettes overriding the `--vscode-*` tokens; dark syntax-highlight selectors guarded with `:not(.mdfh-force-light)` and given `.mdfh-force-dark` alternates.
+  - `src/__tests__/editor/undoSync.test.ts` - updated two payload assertions for the new `editorTheme` field.
+  - `scripts/verify-build.js` - added `toggleTheme` and `.mdfh-force-dark` as tree-shake guards.
+- **Notes:**
+  - Per-panel `onDidChangeConfiguration` means a single global config write re-themes every open editor with no extra broadcast code.
+  - Verified: 873 tests pass, `npm run build:release` + `verify-build` pass (7/7, 6/6, 4/4 features).
+  - Pre-existing repo state: the Windows checkout is CRLF (`core.autocrlf=true`) while prettier expects LF, so `npm run lint` reports CRLF errors across all files (not introduced here). Git normalizes to LF on commit. No non-CRLF lint issues in the changed files.
+- **Remaining:** manual verification in the Extension Development Host (the webview/provider are excluded from unit coverage by design) and a screen recording for the PR per CONTRIBUTING.
 
 ---
 

--- a/roadmap/pipeline/task-editor-theme-override.md
+++ b/roadmap/pipeline/task-editor-theme-override.md
@@ -148,6 +148,16 @@
   - Pre-existing repo state: the Windows checkout is CRLF (`core.autocrlf=true`) while prettier expects LF, so `npm run lint` reports CRLF errors across all files (not introduced here). Git normalizes to LF on commit. No non-CRLF lint issues in the changed files.
 - **Remaining:** manual verification in the Extension Development Host (the webview/provider are excluded from unit coverage by design) and a screen recording for the PR per CONTRIBUTING.
 
+### 2026-05-27 - Refinements from local VSIX testing
+
+Three issues surfaced while testing packaged builds; each was root-caused and fixed:
+
+- **Container/background frame:** the forced palette only set `--vscode-*` on `body`, so the page root and body element backgrounds stayed on the real theme, leaving a mismatched frame around the editor. Fixed by giving `body.mdfh-force-*` an explicit forced `background-color` and adding `html.mdfh-force-*` blocks with a literal page-background color for the overscroll area.
+- **Inherit the real theme:** forcing dark always used the synthetic `#1f1f1f` palette even when the user's VS Code dark theme differed. Replaced `forcedThemeClass(setting)` with `overrideClassFor(setting, vscodeIsDark)`: when the requested direction already matches VS Code's active appearance we apply no override (inherit the live theme); the synthetic palette is used only when forcing the opposite. The provider now reports `vscodeIsDark` (via `appearanceFromKind(activeColorTheme.kind)`) in the payloads and re-broadcasts on `onDidChangeActiveColorTheme` so the decision stays live.
+- **First-load race (needed a second reload):** VS Code reassigns `body.className` during its theme handshake, wiping our class right after the first apply. Made the override self-healing with a `MutationObserver` on the `class` attribute of `html`/`body` that re-asserts the desired state (reconcile only mutates when out of sync, so it settles in one pass).
+
+Test suite updated accordingly (now 875 passing): `overrideClassFor` replaces `forcedThemeClass` in tests; the `vscode` mock and the `inMemoryFiles` inline mock gained `activeColorTheme` + `onDidChangeActiveColorTheme`; `undoSync` payload assertions include `vscodeIsDark`.
+
 ---
 
 ## 8. Decisions & Tradeoffs

--- a/roadmap/pipeline/task-editor-theme-override.md
+++ b/roadmap/pipeline/task-editor-theme-override.md
@@ -1,0 +1,149 @@
+# Task: Editor Theme Override (Display setting + toolbar toggle)
+
+## 1. Task Metadata
+
+- **Task name:** Editor Theme Override
+- **Slug:** editor-theme-override
+- **Status:** planned
+- **Created:** 2026-05-26
+- **Last updated:** 2026-05-26
+- **Shipped:** _(pending)_
+
+---
+
+## 2. Context & Problem
+
+**Current state:**
+- The WYSIWYG editor derives every color from `--vscode-*` CSS variables (`src/webview/editor.css:6-30`), so its appearance always mirrors the user's active VS Code color theme.
+- Syntax-highlighting rules are scoped to the webview body class `.vscode-dark`, which VS Code sets based on the active theme.
+- There is no way to view the editor in a light skin while VS Code is dark (or vice versa).
+
+**Pain points:**
+- **No independent control:** A user who keeps VS Code in dark mode cannot preview/edit a document with a light "paper" look without changing their whole VS Code theme.
+- **No quick switch:** Even if a preference existed, flipping it should be one click from the editor, not a trip into Settings.
+
+**Why it matters:**
+- Writing and reviewing prose often benefits from a light reading surface even when the rest of the IDE is dark.
+- Document-centric editors (Typora, Obsidian, Notion) all let the document surface be themed independently of the chrome. This brings the editor to parity.
+
+---
+
+## 3. Desired Outcome & Scope
+
+**Success criteria:**
+- A new setting `markdownForHumans.display.editorTheme` offers: Follow VS Code theme (default), Always use the default light theme, Always use the default dark theme.
+- Selecting a forced theme renders the editor (content + toolbar) in a self-contained light or dark palette regardless of the active VS Code theme.
+- A toolbar button toggles between the default light and default dark theme; the change applies to every open editor instance, not just the current file.
+- "Follow VS Code theme" reproduces today's behavior exactly (no regression).
+- Code blocks keep correct syntax-highlight colors under a forced theme.
+
+**In scope:**
+- The `editorTheme` enum setting (`scope: application`).
+- A `color-mode` toolbar toggle button that writes the opposite of the currently effective appearance to global config.
+- Self-contained light and dark palettes in `editor.css`, applied via a body class.
+- Re-scoping the `.vscode-dark` syntax-highlight block to also fire under forced dark.
+- Broadcasting the setting to all open panels on change (reusing the existing flow).
+
+**Out of scope:**
+- Per-file persistence of the theme choice (the toggle changes the global default for all files by design).
+- Custom / user-defined palettes.
+- Storing the choice in document frontmatter.
+- Mirroring the user's *specific* configured light/dark theme; we use fixed Light+/Dark+ stock palettes.
+
+---
+
+## 4. UX & Behavior
+
+**Entry points:**
+- Settings UI: `Markdown for Humans > Display: Editor Theme`.
+- Toolbar: a `color-mode` (half-filled circle) button near the gear/settings button.
+
+**User flows:**
+
+### Flow 1: Choose a fixed theme from Settings
+1. User sets `Display: Editor Theme` to "Always use the default dark theme".
+2. All open Markdown for Humans editors re-render in the fixed dark palette immediately.
+3. New editors open in the fixed dark palette.
+
+### Flow 2: Quick toggle from the toolbar
+1. Setting is "Follow VS Code theme"; VS Code is dark, so the editor shows dark.
+2. User clicks the toolbar theme toggle.
+3. Extension computes the effective appearance (dark) and writes the opposite (`defaultLight`) to global config.
+4. All open editors switch to the fixed light palette. Subsequent clicks flip Light <-> Dark.
+
+**Behavior rules:**
+- Effective appearance resolution: if `editorTheme === 'vscode'`, use `vscode.window.activeColorTheme.kind` (Dark and HighContrast -> dark; Light and HighContrastLight -> light); otherwise use the setting value.
+- The toggle only ever writes `defaultLight` or `defaultDark`. "Follow VS Code theme" is re-selectable only from the Settings dropdown.
+- The config write targets `ConfigurationTarget.Global` so it changes the default for all windows/files.
+- When `editorTheme === 'vscode'`, no override class is applied and the editor behaves exactly as today.
+
+---
+
+## 5. Technical Plan
+
+**Surfaces:**
+- Extension host (VS Code API): settings contribution, config read/broadcast, toggle message handler.
+- Webview (TipTap editor): toolbar button, apply/clear override class.
+- Styles: `editor.css` light/dark palettes.
+
+**Key changes:**
+- `package.json` - add `markdownForHumans.display.editorTheme` enum under `contributes.configuration` (with `enumDescriptions`, `scope: application`).
+- `src/editor/MarkdownEditorProvider.ts` - read `editorTheme`, include it in the `update`, `ready`, and `settingsUpdate` payloads; extend `onDidChangeConfiguration` to watch `markdownForHumans.display.editorTheme`; add a `toggleTheme` message handler that calls a pure resolver and writes opposite value to global config.
+- `src/editor/themeResolver.ts` (new) - pure function `resolveToggleTarget(setting, vscodeKind) => 'defaultLight' | 'defaultDark'` so it is unit-testable without VS Code.
+- `src/webview/BubbleMenuView.ts` - add the `color-mode` toggle button (posts `{type:'toggleTheme'}`).
+- `src/webview/editor.ts` - handle `editorTheme` in `update`/`settingsUpdate`; add `applyThemeOverride(mode)` next to `applyEditorSettings()` to set/clear `mdfh-force-light`/`mdfh-force-dark` on `document.body`.
+- `src/webview/editor.css` - define `.mdfh-force-light` and `.mdfh-force-dark` blocks that override the `--vscode-*` variables the editor consumes (editor bg/fg, widget bg/border, button bg/fg, link, code bg, panel border, list hover, focus border); add `.mdfh-force-dark` as a sibling selector to the existing `.vscode-dark` syntax-highlight rules.
+
+**Architecture notes:**
+- Single source of truth is the `editorTheme` setting; the toggle is a binary writer to it. No new persistence layer.
+- Overriding the underlying `--vscode-*` variables (rather than each `--md-*` token or per-rule colors) means both content and toolbar chrome re-theme from one class with no per-rule edits.
+- Reuses the existing `settingsUpdate` broadcast and `onDidChangeConfiguration` plumbing already used for zoom and paragraph spacing.
+
+**Performance considerations:**
+- Theme change is a class toggle + CSS variable recompute; negligible. No layout/typing impact.
+
+---
+
+## 6. Work Breakdown
+
+- [ ] **Phase 1: Setting + plumbing** - declare setting, flow value to webview
+  - [ ] Add `markdownForHumans.display.editorTheme` to `package.json`
+  - [ ] Include `editorTheme` in `update`/`ready`/`settingsUpdate` payloads
+  - [ ] Watch the setting in `onDidChangeConfiguration` and broadcast to all panels
+- [ ] **Phase 2: Theme resolver (TDD)** - pure toggle logic
+  - [ ] Write failing tests for `resolveToggleTarget` (all settings x dark/light/HC)
+  - [ ] Implement `src/editor/themeResolver.ts`
+- [ ] **Phase 3: Toolbar toggle** - UI + message
+  - [ ] Add `color-mode` button in `BubbleMenuView.ts` posting `toggleTheme`
+  - [ ] Handle `toggleTheme` in provider: resolve target, `config.update(..., Global)`
+- [ ] **Phase 4: CSS palettes** - forced light/dark
+  - [ ] Add `.mdfh-force-light` / `.mdfh-force-dark` variable overrides
+  - [ ] Re-scope `.vscode-dark` syntax-highlight rules to include forced dark
+  - [ ] Add `applyThemeOverride()` in `editor.ts` and wire to messages
+- [ ] **Testing**
+  - [ ] Unit tests for `resolveToggleTarget`
+  - [ ] Webview test that `applyThemeOverride` sets/clears the correct body class
+  - [ ] Manual: each setting value x VS Code dark/light; toggle across multiple open files; code-block colors; `npm run verify-build`
+
+---
+
+## 7. Implementation Log
+
+_(Fill in as you implement.)_
+
+---
+
+## 8. Decisions & Tradeoffs
+
+- **Toggle writes global config (not per-file state):** Matches the requested "changes the default for all opened files" behavior and avoids a new persistence layer. Tradeoff: no per-file theme memory.
+- **Override `--vscode-*` variables on a body class:** Cascades to content and toolbar with no per-rule edits. Tradeoff: relies on the editor consuming `--vscode-*` consistently (true today).
+- **Fixed Light+/Dark+ palettes:** Predictable and simple. Tradeoff: does not mirror the user's specific configured theme.
+- **"Follow VS Code" only via dropdown:** A binary toggle cannot cleanly represent three states; keeping "Follow" in Settings keeps the icon meaning unambiguous.
+
+---
+
+## 9. Follow-up & Future Work
+
+- Optional per-file theme memory (workspace state keyed by URI).
+- User-customizable palette tokens.
+- Auto-detect OS color scheme as a fourth mode.

--- a/scripts/verify-build.js
+++ b/scripts/verify-build.js
@@ -49,6 +49,7 @@ const CRITICAL_FEATURES = {
       'skipResizeWarning', // Setting name
       'resizeImage', // Message type
       'copyLocalImageToWorkspace', // Feature
+      'toggleTheme', // Editor theme toggle message
     ],
   },
   webviewCss: {
@@ -59,6 +60,7 @@ const CRITICAL_FEATURES = {
       '.image-resize-modal-overlay',
       '.image-wrapper',
       '.markdown-image',
+      '.mdfh-force-dark', // Forced editor theme palette
     ],
   },
   extensionJs: {
@@ -67,6 +69,7 @@ const CRITICAL_FEATURES = {
       'resizeImage',
       'checkImageInWorkspace',
       'copyLocalImageToWorkspace',
+      'toggleTheme', // Editor theme toggle handler
     ],
   },
 };

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -75,6 +75,8 @@ export const window = {
   }),
   showSaveDialog: jest.fn(),
   showOpenDialog: jest.fn(),
+  activeColorTheme: { kind: 2 }, // ColorThemeKind.Dark
+  onDidChangeActiveColorTheme: jest.fn(() => ({ dispose: jest.fn() })),
 };
 
 // Mock workspace API
@@ -111,6 +113,14 @@ export const Uri = {
 export const env = {
   openExternal: jest.fn(),
 };
+
+// Mock ColorThemeKind enum (matches VS Code's stable values)
+export enum ColorThemeKind {
+  Light = 1,
+  Dark = 2,
+  HighContrast = 3,
+  HighContrastLight = 4,
+}
 
 // Mock ConfigurationTarget enum
 export enum ConfigurationTarget {

--- a/src/__tests__/editor/editorTheme.test.ts
+++ b/src/__tests__/editor/editorTheme.test.ts
@@ -1,7 +1,7 @@
 import {
   appearanceFromKind,
   effectiveAppearance,
-  forcedThemeClass,
+  overrideClassFor,
   resolveToggleTarget,
 } from '../../shared/editorTheme';
 
@@ -67,16 +67,25 @@ describe('resolveToggleTarget', () => {
   });
 });
 
-describe('forcedThemeClass', () => {
+describe('overrideClassFor', () => {
   it('applies no override class when following VS Code', () => {
-    expect(forcedThemeClass('vscode')).toBeNull();
+    expect(overrideClassFor('vscode', true)).toBeNull();
+    expect(overrideClassFor('vscode', false)).toBeNull();
   });
 
-  it('applies the forced-light class when the setting is "defaultLight"', () => {
-    expect(forcedThemeClass('defaultLight')).toBe('mdfh-force-light');
+  it('inherits the live theme when forcing dark and VS Code is already dark', () => {
+    expect(overrideClassFor('defaultDark', true)).toBeNull();
   });
 
-  it('applies the forced-dark class when the setting is "defaultDark"', () => {
-    expect(forcedThemeClass('defaultDark')).toBe('mdfh-force-dark');
+  it('inherits the live theme when forcing light and VS Code is already light', () => {
+    expect(overrideClassFor('defaultLight', false)).toBeNull();
+  });
+
+  it('applies the synthetic dark palette when forcing dark over a light VS Code', () => {
+    expect(overrideClassFor('defaultDark', false)).toBe('mdfh-force-dark');
+  });
+
+  it('applies the synthetic light palette when forcing light over a dark VS Code', () => {
+    expect(overrideClassFor('defaultLight', true)).toBe('mdfh-force-light');
   });
 });

--- a/src/__tests__/editor/editorTheme.test.ts
+++ b/src/__tests__/editor/editorTheme.test.ts
@@ -1,0 +1,82 @@
+import {
+  appearanceFromKind,
+  effectiveAppearance,
+  forcedThemeClass,
+  resolveToggleTarget,
+} from '../../shared/editorTheme';
+
+// VS Code ColorThemeKind numeric values (stable API enum):
+// Light = 1, Dark = 2, HighContrast = 3 (dark), HighContrastLight = 4
+const LIGHT = 1;
+const DARK = 2;
+const HIGH_CONTRAST = 3;
+const HIGH_CONTRAST_LIGHT = 4;
+
+describe('appearanceFromKind', () => {
+  it('maps the Light kind to light', () => {
+    expect(appearanceFromKind(LIGHT)).toBe('light');
+  });
+
+  it('maps the Dark kind to dark', () => {
+    expect(appearanceFromKind(DARK)).toBe('dark');
+  });
+
+  it('maps the HighContrast (dark) kind to dark', () => {
+    expect(appearanceFromKind(HIGH_CONTRAST)).toBe('dark');
+  });
+
+  it('maps the HighContrastLight kind to light', () => {
+    expect(appearanceFromKind(HIGH_CONTRAST_LIGHT)).toBe('light');
+  });
+});
+
+describe('effectiveAppearance', () => {
+  it('follows VS Code when the setting is "vscode"', () => {
+    expect(effectiveAppearance('vscode', DARK)).toBe('dark');
+    expect(effectiveAppearance('vscode', LIGHT)).toBe('light');
+  });
+
+  it('forces light regardless of VS Code when the setting is "defaultLight"', () => {
+    expect(effectiveAppearance('defaultLight', DARK)).toBe('light');
+  });
+
+  it('forces dark regardless of VS Code when the setting is "defaultDark"', () => {
+    expect(effectiveAppearance('defaultDark', LIGHT)).toBe('dark');
+  });
+});
+
+describe('resolveToggleTarget', () => {
+  it('writes light when the editor currently shows dark via VS Code', () => {
+    expect(resolveToggleTarget('vscode', DARK)).toBe('defaultLight');
+  });
+
+  it('writes dark when the editor currently shows light via VS Code', () => {
+    expect(resolveToggleTarget('vscode', LIGHT)).toBe('defaultDark');
+  });
+
+  it('writes light when the setting already forces dark', () => {
+    expect(resolveToggleTarget('defaultDark', LIGHT)).toBe('defaultLight');
+  });
+
+  it('writes dark when the setting already forces light', () => {
+    expect(resolveToggleTarget('defaultLight', DARK)).toBe('defaultDark');
+  });
+
+  it('treats HighContrast (dark) as dark and writes light', () => {
+    expect(resolveToggleTarget('vscode', HIGH_CONTRAST)).toBe('defaultLight');
+  });
+});
+
+describe('forcedThemeClass', () => {
+  it('applies no override class when following VS Code', () => {
+    expect(forcedThemeClass('vscode')).toBeNull();
+  });
+
+  it('applies the forced-light class when the setting is "defaultLight"', () => {
+    expect(forcedThemeClass('defaultLight')).toBe('mdfh-force-light');
+  });
+
+  it('applies the forced-dark class when the setting is "defaultDark"', () => {
+    expect(forcedThemeClass('defaultDark')).toBe('mdfh-force-dark');
+  });
+});

--- a/src/__tests__/editor/inMemoryFiles.test.ts
+++ b/src/__tests__/editor/inMemoryFiles.test.ts
@@ -39,6 +39,8 @@ jest.mock('vscode', () => ({
   window: {
     showInformationMessage: jest.fn(),
     showErrorMessage: jest.fn(),
+    activeColorTheme: { kind: 2 }, // ColorThemeKind.Dark
+    onDidChangeActiveColorTheme: jest.fn(() => ({ dispose: jest.fn() })),
   },
   workspace: {
     getWorkspaceFolder: jest.fn(),

--- a/src/__tests__/editor/undoSync.test.ts
+++ b/src/__tests__/editor/undoSync.test.ts
@@ -210,6 +210,7 @@ describe('MarkdownEditorProvider undo/redo safety', () => {
       paragraphSpacingBefore: 0,
       paragraphSpacingAfter: 0,
       zoom: 100,
+      editorTheme: 'vscode',
     });
   });
 
@@ -253,6 +254,7 @@ describe('MarkdownEditorProvider undo/redo safety', () => {
       paragraphSpacingBefore: 0,
       paragraphSpacingAfter: 0,
       zoom: 100,
+      editorTheme: 'vscode',
     });
 
     getConfigurationSpy.mockRestore();

--- a/src/__tests__/editor/undoSync.test.ts
+++ b/src/__tests__/editor/undoSync.test.ts
@@ -211,6 +211,7 @@ describe('MarkdownEditorProvider undo/redo safety', () => {
       paragraphSpacingAfter: 0,
       zoom: 100,
       editorTheme: 'vscode',
+      vscodeIsDark: true,
     });
   });
 
@@ -255,6 +256,7 @@ describe('MarkdownEditorProvider undo/redo safety', () => {
       paragraphSpacingAfter: 0,
       zoom: 100,
       editorTheme: 'vscode',
+      vscodeIsDark: true,
     });
 
     getConfigurationSpy.mockRestore();

--- a/src/editor/MarkdownEditorProvider.ts
+++ b/src/editor/MarkdownEditorProvider.ts
@@ -3240,9 +3240,6 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
   }
 
   /**
-   * Handle setting update request from webview
-   */
-  /**
    * Toggle button: write the opposite of the currently effective appearance to
    * the global `editorTheme` setting. The write fires each open panel's own
    * `onDidChangeConfiguration` subscription, so every editor re-themes at once.
@@ -3264,6 +3261,9 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
     }
   }
 
+  /**
+   * Handle setting update request from webview
+   */
   private async handleUpdateSetting(
     message: { type: string; [key: string]: unknown },
     webview: vscode.Webview

--- a/src/editor/MarkdownEditorProvider.ts
+++ b/src/editor/MarkdownEditorProvider.ts
@@ -17,6 +17,7 @@ import { setActiveWebviewPanel, getActiveWebviewPanel } from '../activeWebview';
 import { buildResizeBackupLocation, resolveBackupPathWithCollisionDetection } from './imageBackups';
 import { hasSameBlankLineLayout, isMarkdownStructurallyEquivalent } from './markdownAstEquivalence';
 import { applyBlankLinePolicy, type BlankLineMode } from '../shared/blankLinePolicy';
+import { resolveToggleTarget, type EditorThemeSetting } from '../shared/editorTheme';
 
 /**
  * Coerce text to end with exactly one `\n` (markdownlint MD047). An empty
@@ -163,6 +164,12 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
     const config = vscode.workspace.getConfiguration();
     const value = config.get<string>('markdownForHumans.blankLines.mode', 'strip');
     return value === 'preserve' ? 'preserve' : 'strip';
+  }
+
+  private getEditorTheme(): EditorThemeSetting {
+    const config = vscode.workspace.getConfiguration();
+    const value = config.get<string>('markdownForHumans.display.editorTheme', 'vscode');
+    return value === 'defaultLight' || value === 'defaultDark' ? value : 'vscode';
   }
 
   private async syncMarkdownlintMd012(mode: BlankLineMode): Promise<void> {
@@ -510,7 +517,8 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
         e.affectsConfiguration('markdownForHumans.blankLines.mode') ||
         e.affectsConfiguration('markdownForHumans.paragraph.spacingBefore') ||
         e.affectsConfiguration('markdownForHumans.paragraph.spacingAfter') ||
-        e.affectsConfiguration('markdownForHumans.zoom')
+        e.affectsConfiguration('markdownForHumans.zoom') ||
+        e.affectsConfiguration('markdownForHumans.display.editorTheme')
       ) {
         const config = vscode.workspace.getConfiguration();
         const skipWarning = config.get<boolean>('markdownForHumans.imageResize.skipWarning', false);
@@ -537,6 +545,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
         );
         const zoom = config.get<number>('markdownForHumans.zoom', 100);
         const blankLineMode = this.getBlankLineMode();
+        const editorTheme = this.getEditorTheme();
         if (e.affectsConfiguration('markdownForHumans.blankLines.mode')) {
           void this.syncMarkdownlintMd012(blankLineMode).catch(error => {
             console.warn('[MD4H] Failed syncing markdownlint MD012 rule:', error);
@@ -562,6 +571,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
           paragraphSpacingAfter: paragraphSpacingAfter,
           zoom: zoom,
           blankLineMode,
+          editorTheme,
         });
       }
     });
@@ -659,6 +669,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
     const paragraphSpacingAfter = config.get<number>('markdownForHumans.paragraph.spacingAfter', 0);
     const zoom = config.get<number>('markdownForHumans.zoom', 100);
     const blankLineMode = this.getBlankLineMode();
+    const editorTheme = this.getEditorTheme();
 
     webview.postMessage({
       type: 'update',
@@ -672,6 +683,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
       paragraphSpacingAfter: paragraphSpacingAfter,
       zoom: zoom,
       blankLineMode,
+      editorTheme,
     });
   }
 
@@ -748,6 +760,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
         );
         const zoom = config.get<number>('markdownForHumans.zoom', 100);
         const blankLineMode = this.getBlankLineMode();
+        const editorTheme = this.getEditorTheme();
         webview.postMessage({
           type: 'settingsUpdate',
           skipResizeWarning: skipWarning,
@@ -759,6 +772,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
           paragraphSpacingAfter: paragraphSpacingAfter,
           zoom: zoom,
           blankLineMode,
+          editorTheme,
         });
         break;
       }
@@ -795,6 +809,9 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
           'workbench.action.openSettings',
           '@ext:concretio.markdown-for-humans'
         );
+        break;
+      case 'toggleTheme':
+        void this.handleToggleTheme();
         break;
       case 'exportDocument':
         this.handleExportDocument(message, document);
@@ -3225,6 +3242,28 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
   /**
    * Handle setting update request from webview
    */
+  /**
+   * Toggle button: write the opposite of the currently effective appearance to
+   * the global `editorTheme` setting. The write fires each open panel's own
+   * `onDidChangeConfiguration` subscription, so every editor re-themes at once.
+   */
+  private async handleToggleTheme(): Promise<void> {
+    try {
+      const current = this.getEditorTheme();
+      const kind = vscode.window.activeColorTheme.kind as number;
+      const target = resolveToggleTarget(current, kind);
+      const config = vscode.workspace.getConfiguration();
+      await config.update(
+        'markdownForHumans.display.editorTheme',
+        target,
+        vscode.ConfigurationTarget.Global
+      );
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error(`[MD4H] Failed to toggle editor theme: ${errorMessage}`);
+    }
+  }
+
   private async handleUpdateSetting(
     message: { type: string; [key: string]: unknown },
     webview: vscode.Webview

--- a/src/editor/MarkdownEditorProvider.ts
+++ b/src/editor/MarkdownEditorProvider.ts
@@ -17,7 +17,11 @@ import { setActiveWebviewPanel, getActiveWebviewPanel } from '../activeWebview';
 import { buildResizeBackupLocation, resolveBackupPathWithCollisionDetection } from './imageBackups';
 import { hasSameBlankLineLayout, isMarkdownStructurallyEquivalent } from './markdownAstEquivalence';
 import { applyBlankLinePolicy, type BlankLineMode } from '../shared/blankLinePolicy';
-import { resolveToggleTarget, type EditorThemeSetting } from '../shared/editorTheme';
+import {
+  appearanceFromKind,
+  resolveToggleTarget,
+  type EditorThemeSetting,
+} from '../shared/editorTheme';
 
 /**
  * Coerce text to end with exactly one `\n` (markdownlint MD047). An empty
@@ -170,6 +174,12 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
     const config = vscode.workspace.getConfiguration();
     const value = config.get<string>('markdownForHumans.display.editorTheme', 'vscode');
     return value === 'defaultLight' || value === 'defaultDark' ? value : 'vscode';
+  }
+
+  /** Whether VS Code's active color theme is a dark variant (incl. high contrast). */
+  private isVscodeDark(): boolean {
+    const kind = vscode.window.activeColorTheme?.kind;
+    return typeof kind === 'number' ? appearanceFromKind(kind) === 'dark' : false;
   }
 
   private async syncMarkdownlintMd012(mode: BlankLineMode): Promise<void> {
@@ -546,6 +556,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
         const zoom = config.get<number>('markdownForHumans.zoom', 100);
         const blankLineMode = this.getBlankLineMode();
         const editorTheme = this.getEditorTheme();
+        const vscodeIsDark = this.isVscodeDark();
         if (e.affectsConfiguration('markdownForHumans.blankLines.mode')) {
           void this.syncMarkdownlintMd012(blankLineMode).catch(error => {
             console.warn('[MD4H] Failed syncing markdownlint MD012 rule:', error);
@@ -572,8 +583,22 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
           zoom: zoom,
           blankLineMode,
           editorTheme,
+          vscodeIsDark,
         });
       }
+    });
+
+    // When VS Code's active color theme changes, re-send the theme settings so
+    // the webview can re-evaluate the override. This matters for the "inherit
+    // when the active appearance matches" behavior: e.g. an editor set to
+    // "Always dark" that was inheriting a live dark theme must switch to the
+    // synthetic dark palette if the user flips VS Code to a light theme.
+    const themeChangeSubscription = vscode.window.onDidChangeActiveColorTheme(() => {
+      webviewPanel.webview.postMessage({
+        type: 'settingsUpdate',
+        editorTheme: this.getEditorTheme(),
+        vscodeIsDark: this.isVscodeDark(),
+      });
     });
 
     webviewPanel.onDidChangeViewState(() => {
@@ -602,6 +627,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
     webviewPanel.onDidDispose(() => {
       changeDocumentSubscription.dispose();
       configChangeSubscription.dispose();
+      themeChangeSubscription.dispose();
       // Clean up pending edits tracking for this document
       const docUri = document.uri.toString();
       this.pendingEdits.delete(docUri);
@@ -684,6 +710,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
       zoom: zoom,
       blankLineMode,
       editorTheme,
+      vscodeIsDark: this.isVscodeDark(),
     });
   }
 
@@ -773,6 +800,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
           zoom: zoom,
           blankLineMode,
           editorTheme,
+          vscodeIsDark: this.isVscodeDark(),
         });
         break;
       }

--- a/src/shared/editorTheme.ts
+++ b/src/shared/editorTheme.ts
@@ -1,0 +1,54 @@
+/**
+ * Pure helpers for the editor theme override feature.
+ *
+ * Kept free of any `vscode` import so the toggle logic can be unit-tested in
+ * isolation. The extension host passes in the raw `ColorThemeKind` numeric
+ * value from `vscode.window.activeColorTheme.kind`.
+ */
+
+/** The value of the `markdownForHumans.display.editorTheme` setting. */
+export type EditorThemeSetting = 'vscode' | 'defaultLight' | 'defaultDark';
+
+/** A forced theme the toolbar toggle can write back to the setting. */
+export type ForcedTheme = 'defaultLight' | 'defaultDark';
+
+/** The light/dark appearance the editor actually renders. */
+export type Appearance = 'light' | 'dark';
+
+/**
+ * VS Code `ColorThemeKind` numeric values (stable enum):
+ * Light = 1, Dark = 2, HighContrast = 3 (a dark variant), HighContrastLight = 4.
+ * High-contrast dark counts as dark; high-contrast light counts as light.
+ */
+export function appearanceFromKind(kind: number): Appearance {
+  return kind === 2 || kind === 3 ? 'dark' : 'light';
+}
+
+/**
+ * Resolves what the editor currently shows: the forced value when the setting
+ * pins light/dark, otherwise whatever VS Code's active theme implies.
+ */
+export function effectiveAppearance(setting: EditorThemeSetting, vscodeKind: number): Appearance {
+  if (setting === 'defaultLight') return 'light';
+  if (setting === 'defaultDark') return 'dark';
+  return appearanceFromKind(vscodeKind);
+}
+
+/**
+ * The toolbar toggle writes the opposite of the currently effective appearance,
+ * so a single click always flips the visible theme.
+ */
+export function resolveToggleTarget(setting: EditorThemeSetting, vscodeKind: number): ForcedTheme {
+  return effectiveAppearance(setting, vscodeKind) === 'dark' ? 'defaultLight' : 'defaultDark';
+}
+
+/**
+ * The body class the webview applies for a given setting, or `null` to follow
+ * VS Code's own theme (no override). Depends only on the setting: when forcing
+ * a palette the VS Code theme is irrelevant.
+ */
+export function forcedThemeClass(setting: EditorThemeSetting): string | null {
+  if (setting === 'defaultLight') return 'mdfh-force-light';
+  if (setting === 'defaultDark') return 'mdfh-force-dark';
+  return null;
+}

--- a/src/shared/editorTheme.ts
+++ b/src/shared/editorTheme.ts
@@ -43,12 +43,21 @@ export function resolveToggleTarget(setting: EditorThemeSetting, vscodeKind: num
 }
 
 /**
- * The body class the webview applies for a given setting, or `null` to follow
- * VS Code's own theme (no override). Depends only on the setting: when forcing
- * a palette the VS Code theme is irrelevant.
+ * The override class the webview applies, or `null` to inherit VS Code's live
+ * theme (no override).
+ *
+ * Key behavior: when the requested direction already matches VS Code's active
+ * appearance, we return `null` so the editor inherits the real theme (best
+ * fidelity - matches whatever dark/light theme the user actually uses). The
+ * synthetic palette is applied only when forcing the *opposite* of the active
+ * appearance, where there is no live theme to inherit.
  */
-export function forcedThemeClass(setting: EditorThemeSetting): string | null {
-  if (setting === 'defaultLight') return 'mdfh-force-light';
-  if (setting === 'defaultDark') return 'mdfh-force-dark';
-  return null;
+export function overrideClassFor(
+  setting: EditorThemeSetting,
+  vscodeIsDark: boolean
+): string | null {
+  if (setting === 'vscode') return null;
+  const wantDark = setting === 'defaultDark';
+  if (wantDark === vscodeIsDark) return null; // active theme already matches -> inherit it
+  return wantDark ? 'mdfh-force-dark' : 'mdfh-force-light';
 }

--- a/src/webview/BubbleMenuView.ts
+++ b/src/webview/BubbleMenuView.ts
@@ -660,6 +660,17 @@ export function createFormattingToolbar(editor: Editor): HTMLElement {
       isActive: () => false,
       className: 'settings-button',
     },
+    {
+      type: 'button',
+      label: 'Toggle light/dark theme',
+      title: 'Toggle light/dark theme (applies to all open editors)',
+      icon: { name: 'color-mode', fallback: '◐' },
+      action: () => {
+        window.dispatchEvent(new CustomEvent('toggleTheme'));
+      },
+      isActive: () => false,
+      className: 'theme-toggle-button',
+    },
   ];
 
   const actionButtons: Array<{ config: ToolbarActionButton; element: HTMLButtonElement }> = [];

--- a/src/webview/editor.css
+++ b/src/webview/editor.css
@@ -61,6 +61,16 @@
     --vscode-editor-findMatchBackground: #a8ac94;
     --vscode-editor-findMatchHighlightBackground: rgba(234, 92, 0, 0.33);
     color-scheme: light;
+    background-color: var(--vscode-editor-background);
+    color: var(--vscode-editor-foreground);
+  }
+
+  /* Root (overscroll/page) background. Uses a literal color, not the variable,
+     because VS Code sets --vscode-* inline on <html>, so a class rule can only
+     override the background property there, not the variables. */
+  html.mdfh-force-light {
+    background-color: #ffffff;
+    color-scheme: light;
   }
 
   body.mdfh-force-dark {
@@ -112,6 +122,13 @@
     --vscode-terminal-ansiRed: #f14c4c;
     --vscode-editor-findMatchBackground: #9e6a03;
     --vscode-editor-findMatchHighlightBackground: rgba(234, 92, 0, 0.33);
+    color-scheme: dark;
+    background-color: var(--vscode-editor-background);
+    color: var(--vscode-editor-foreground);
+  }
+
+  html.mdfh-force-dark {
+    background-color: #1f1f1f;
     color-scheme: dark;
   }
 

--- a/src/webview/editor.css
+++ b/src/webview/editor.css
@@ -1,4 +1,121 @@
 /* ============================================
+   Forced Theme Override (Display: Editor Theme)
+
+   When markdownForHumans.display.editorTheme is set to a fixed theme, the
+   webview adds .mdfh-force-light / .mdfh-force-dark to <body>. Both the editor
+   content and the toolbar read --vscode-* tokens, so redefining that token set
+   on body (closer + at least as specific as VS Code's :root declarations) is
+   enough to re-skin everything with one class and no per-rule edits. Values
+   mirror VS Code's stock Light Modern and Dark Modern palettes. When the
+   setting is "vscode", no class is applied and VS Code's own theme drives the
+   appearance exactly as before.
+   ============================================ */
+
+  body.mdfh-force-light {
+    --vscode-editor-background: #ffffff;
+    --vscode-editor-foreground: #3b3b3b;
+    --vscode-foreground: #3b3b3b;
+    --vscode-descriptionForeground: #767676;
+    --vscode-editorWidget-background: #f8f8f8;
+    --vscode-editorWidget-border: #d4d4d4;
+    --vscode-editorWidget-foreground: #3b3b3b;
+    --vscode-widget-border: #d4d4d4;
+    --vscode-widget-shadow: rgba(0, 0, 0, 0.16);
+    --vscode-panel-border: #e5e5e5;
+    --vscode-focusBorder: #005fb8;
+    --vscode-button-background: #005fb8;
+    --vscode-button-foreground: #ffffff;
+    --vscode-button-hoverBackground: #0258a8;
+    --vscode-button-activeBackground: #005fb8;
+    --vscode-button-border: rgba(0, 0, 0, 0.1);
+    --vscode-list-hoverBackground: #f0f0f0;
+    --vscode-list-activeSelectionBackground: #e8e8e8;
+    --vscode-editor-selectionBackground: #add6ff;
+    --vscode-textLink-foreground: #005fb8;
+    --vscode-textLink-activeForeground: #005fb8;
+    --vscode-textCodeBlock-background: #f0f0f0;
+    --vscode-textPreformat-foreground: #a31515;
+    --vscode-textBlockQuote-background: #f8f8f8;
+    --vscode-textBlockQuote-border: #d4d4d4;
+    --vscode-dropdown-background: #ffffff;
+    --vscode-dropdown-border: #cecece;
+    --vscode-dropdown-foreground: #3b3b3b;
+    --vscode-input-background: #ffffff;
+    --vscode-input-border: #cecece;
+    --vscode-input-foreground: #3b3b3b;
+    --vscode-input-placeholderForeground: #767676;
+    --vscode-menu-background: #ffffff;
+    --vscode-menu-border: #cecece;
+    --vscode-menu-foreground: #3b3b3b;
+    --vscode-menu-selectionBackground: #005fb8;
+    --vscode-menu-selectionForeground: #ffffff;
+    --vscode-menu-separatorBackground: #d4d4d4;
+    --vscode-editorHoverWidget-background: #f8f8f8;
+    --vscode-editorHoverWidget-border: #d4d4d4;
+    --vscode-editorHoverWidget-foreground: #3b3b3b;
+    --vscode-editorError-foreground: #e51400;
+    --vscode-errorForeground: #e51400;
+    --vscode-charts-green: #388a34;
+    --vscode-terminal-ansiGreen: #00bc00;
+    --vscode-terminal-ansiRed: #cd3131;
+    --vscode-editor-findMatchBackground: #a8ac94;
+    --vscode-editor-findMatchHighlightBackground: rgba(234, 92, 0, 0.33);
+    color-scheme: light;
+  }
+
+  body.mdfh-force-dark {
+    --vscode-editor-background: #1f1f1f;
+    --vscode-editor-foreground: #cccccc;
+    --vscode-foreground: #cccccc;
+    --vscode-descriptionForeground: #9d9d9d;
+    --vscode-editorWidget-background: #202020;
+    --vscode-editorWidget-border: #454545;
+    --vscode-editorWidget-foreground: #cccccc;
+    --vscode-widget-border: #313131;
+    --vscode-widget-shadow: rgba(0, 0, 0, 0.36);
+    --vscode-panel-border: #2b2b2b;
+    --vscode-focusBorder: #0078d4;
+    --vscode-button-background: #0078d4;
+    --vscode-button-foreground: #ffffff;
+    --vscode-button-hoverBackground: #026ec1;
+    --vscode-button-activeBackground: #0078d4;
+    --vscode-button-border: rgba(255, 255, 255, 0.07);
+    --vscode-list-hoverBackground: #2a2d2e;
+    --vscode-list-activeSelectionBackground: #04395e;
+    --vscode-editor-selectionBackground: #264f78;
+    --vscode-textLink-foreground: #4daafc;
+    --vscode-textLink-activeForeground: #4daafc;
+    --vscode-textCodeBlock-background: #2a2a2a;
+    --vscode-textPreformat-foreground: #d7ba7d;
+    --vscode-textBlockQuote-background: #2a2a2a;
+    --vscode-textBlockQuote-border: #616161;
+    --vscode-dropdown-background: #313131;
+    --vscode-dropdown-border: #3c3c3c;
+    --vscode-dropdown-foreground: #cccccc;
+    --vscode-input-background: #313131;
+    --vscode-input-border: #3c3c3c;
+    --vscode-input-foreground: #cccccc;
+    --vscode-input-placeholderForeground: #989898;
+    --vscode-menu-background: #1f1f1f;
+    --vscode-menu-border: #454545;
+    --vscode-menu-foreground: #cccccc;
+    --vscode-menu-selectionBackground: #0078d4;
+    --vscode-menu-selectionForeground: #ffffff;
+    --vscode-menu-separatorBackground: #454545;
+    --vscode-editorHoverWidget-background: #202020;
+    --vscode-editorHoverWidget-border: #454545;
+    --vscode-editorHoverWidget-foreground: #cccccc;
+    --vscode-editorError-foreground: #f14c4c;
+    --vscode-errorForeground: #f14c4c;
+    --vscode-charts-green: #89d185;
+    --vscode-terminal-ansiGreen: #23d18b;
+    --vscode-terminal-ansiRed: #f14c4c;
+    --vscode-editor-findMatchBackground: #9e6a03;
+    --vscode-editor-findMatchHighlightBackground: rgba(234, 92, 0, 0.33);
+    color-scheme: dark;
+  }
+
+/* ============================================
    Theme-Aware Color System
    All colors derive from VS Code theme
    ============================================ */
@@ -355,105 +472,152 @@
      for better contrast and visibility in dark themes.
      ============================================ */
   
-  .vscode-dark .code-block-highlighted,
-  .vscode-high-contrast .code-block-highlighted {
+    .vscode-dark:not(.mdfh-force-light) .code-block-highlighted,
+  .mdfh-force-dark .code-block-highlighted,
+  .vscode-high-contrast:not(.mdfh-force-light) .code-block-highlighted {
     background-color: #161b22;
     border-color: #30363d;
   }
-  
-  .vscode-dark .code-block-highlighted .hljs-doctag,
-  .vscode-dark .code-block-highlighted .hljs-keyword,
-  .vscode-dark .code-block-highlighted .hljs-meta .hljs-keyword,
-  .vscode-dark .code-block-highlighted .hljs-template-tag,
-  .vscode-dark .code-block-highlighted .hljs-template-variable,
-  .vscode-dark .code-block-highlighted .hljs-type,
-  .vscode-dark .code-block-highlighted .hljs-variable.language_ {
+
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-doctag,
+  .mdfh-force-dark .code-block-highlighted .hljs-doctag,
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-keyword,
+  .mdfh-force-dark .code-block-highlighted .hljs-keyword,
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-meta .hljs-keyword,
+  .mdfh-force-dark .code-block-highlighted .hljs-meta .hljs-keyword,
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-template-tag,
+  .mdfh-force-dark .code-block-highlighted .hljs-template-tag,
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-template-variable,
+  .mdfh-force-dark .code-block-highlighted .hljs-template-variable,
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-type,
+  .mdfh-force-dark .code-block-highlighted .hljs-type,
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-variable.language_,
+  .mdfh-force-dark .code-block-highlighted .hljs-variable.language_ {
     color: #ff7b72;
   }
-  
-  .vscode-dark .code-block-highlighted .hljs-title,
-  .vscode-dark .code-block-highlighted .hljs-title.class_,
-  .vscode-dark .code-block-highlighted .hljs-title.class_.inherited__,
-  .vscode-dark .code-block-highlighted .hljs-title.function_ {
+
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-title,
+  .mdfh-force-dark .code-block-highlighted .hljs-title,
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-title.class_,
+  .mdfh-force-dark .code-block-highlighted .hljs-title.class_,
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-title.class_.inherited__,
+  .mdfh-force-dark .code-block-highlighted .hljs-title.class_.inherited__,
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-title.function_,
+  .mdfh-force-dark .code-block-highlighted .hljs-title.function_ {
     color: #d2a8ff;
   }
-  
-  .vscode-dark .code-block-highlighted .hljs-attr,
-  .vscode-dark .code-block-highlighted .hljs-attribute,
-  .vscode-dark .code-block-highlighted .hljs-literal,
-  .vscode-dark .code-block-highlighted .hljs-meta,
-  .vscode-dark .code-block-highlighted .hljs-number,
-  .vscode-dark .code-block-highlighted .hljs-operator,
-  .vscode-dark .code-block-highlighted .hljs-variable,
-  .vscode-dark .code-block-highlighted .hljs-selector-attr,
-  .vscode-dark .code-block-highlighted .hljs-selector-class,
-  .vscode-dark .code-block-highlighted .hljs-selector-id {
+
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-attr,
+  .mdfh-force-dark .code-block-highlighted .hljs-attr,
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-attribute,
+  .mdfh-force-dark .code-block-highlighted .hljs-attribute,
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-literal,
+  .mdfh-force-dark .code-block-highlighted .hljs-literal,
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-meta,
+  .mdfh-force-dark .code-block-highlighted .hljs-meta,
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-number,
+  .mdfh-force-dark .code-block-highlighted .hljs-number,
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-operator,
+  .mdfh-force-dark .code-block-highlighted .hljs-operator,
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-variable,
+  .mdfh-force-dark .code-block-highlighted .hljs-variable,
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-selector-attr,
+  .mdfh-force-dark .code-block-highlighted .hljs-selector-attr,
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-selector-class,
+  .mdfh-force-dark .code-block-highlighted .hljs-selector-class,
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-selector-id,
+  .mdfh-force-dark .code-block-highlighted .hljs-selector-id {
     color: #79c0ff;
   }
-  
-  .vscode-dark .code-block-highlighted .hljs-regexp,
-  .vscode-dark .code-block-highlighted .hljs-string,
-  .vscode-dark .code-block-highlighted .hljs-meta .hljs-string {
+
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-regexp,
+  .mdfh-force-dark .code-block-highlighted .hljs-regexp,
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-string,
+  .mdfh-force-dark .code-block-highlighted .hljs-string,
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-meta .hljs-string,
+  .mdfh-force-dark .code-block-highlighted .hljs-meta .hljs-string {
     color: #a5d6ff;
   }
-  
-  .vscode-dark .code-block-highlighted .hljs-built_in,
-  .vscode-dark .code-block-highlighted .hljs-symbol {
+
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-built_in,
+  .mdfh-force-dark .code-block-highlighted .hljs-built_in,
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-symbol,
+  .mdfh-force-dark .code-block-highlighted .hljs-symbol {
     color: #ffa657;
   }
-  
-  .vscode-dark .code-block-highlighted .hljs-comment,
-  .vscode-dark .code-block-highlighted .hljs-code,
-  .vscode-dark .code-block-highlighted .hljs-formula {
+
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-comment,
+  .mdfh-force-dark .code-block-highlighted .hljs-comment,
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-code,
+  .mdfh-force-dark .code-block-highlighted .hljs-code,
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-formula,
+  .mdfh-force-dark .code-block-highlighted .hljs-formula {
     color: #8b949e;
   }
-  
-  .vscode-dark .code-block-highlighted .hljs-name,
-  .vscode-dark .code-block-highlighted .hljs-quote,
-  .vscode-dark .code-block-highlighted .hljs-selector-tag,
-  .vscode-dark .code-block-highlighted .hljs-selector-pseudo {
+
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-name,
+  .mdfh-force-dark .code-block-highlighted .hljs-name,
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-quote,
+  .mdfh-force-dark .code-block-highlighted .hljs-quote,
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-selector-tag,
+  .mdfh-force-dark .code-block-highlighted .hljs-selector-tag,
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-selector-pseudo,
+  .mdfh-force-dark .code-block-highlighted .hljs-selector-pseudo {
     color: #7ee787;
   }
-  
-  .vscode-dark .code-block-highlighted .hljs-subst {
+
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-subst,
+  .mdfh-force-dark .code-block-highlighted .hljs-subst {
     color: #c9d1d9;
   }
-  
-  .vscode-dark .code-block-highlighted .hljs-section {
+
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-section,
+  .mdfh-force-dark .code-block-highlighted .hljs-section {
     color: #1f6feb;
     font-weight: bold;
   }
-  
-  .vscode-dark .code-block-highlighted .hljs-bullet {
+
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-bullet,
+  .mdfh-force-dark .code-block-highlighted .hljs-bullet {
     color: #f2cc60;
   }
-  
-  .vscode-dark .code-block-highlighted .hljs-emphasis {
+
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-emphasis,
+  .mdfh-force-dark .code-block-highlighted .hljs-emphasis {
     color: #c9d1d9;
     font-style: italic;
   }
-  
-  .vscode-dark .code-block-highlighted .hljs-strong {
+
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-strong,
+  .mdfh-force-dark .code-block-highlighted .hljs-strong {
     color: #c9d1d9;
     font-weight: bold;
   }
-  
-  .vscode-dark .code-block-highlighted .hljs-addition {
+
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-addition,
+  .mdfh-force-dark .code-block-highlighted .hljs-addition {
     color: #aff5b4;
     background-color: #033a16;
   }
-  
-  .vscode-dark .code-block-highlighted .hljs-deletion {
+
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-deletion,
+  .mdfh-force-dark .code-block-highlighted .hljs-deletion {
     color: #ffdcd7;
     background-color: #67060c;
   }
-  
-  .vscode-dark .code-block-highlighted .hljs-char.escape_,
-  .vscode-dark .code-block-highlighted .hljs-link,
-  .vscode-dark .code-block-highlighted .hljs-params,
-  .vscode-dark .code-block-highlighted .hljs-property,
-  .vscode-dark .code-block-highlighted .hljs-punctuation,
-  .vscode-dark .code-block-highlighted .hljs-tag {
+
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-char.escape_,
+  .mdfh-force-dark .code-block-highlighted .hljs-char.escape_,
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-link,
+  .mdfh-force-dark .code-block-highlighted .hljs-link,
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-params,
+  .mdfh-force-dark .code-block-highlighted .hljs-params,
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-property,
+  .mdfh-force-dark .code-block-highlighted .hljs-property,
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-punctuation,
+  .mdfh-force-dark .code-block-highlighted .hljs-punctuation,
+  .vscode-dark:not(.mdfh-force-light) .code-block-highlighted .hljs-tag,
+  .mdfh-force-dark .code-block-highlighted .hljs-tag {
     color: #c9d1d9;
   }
   

--- a/src/webview/editor.ts
+++ b/src/webview/editor.ts
@@ -33,6 +33,7 @@ import { DocumentAuditExtension } from './features/auditDocument';
 import { createFormattingToolbar, createTableMenu, updateToolbarStates } from './BubbleMenuView';
 import { getEditorMarkdownForSync } from './utils/markdownSerialization';
 import type { BlankLineMode } from '../shared/blankLinePolicy';
+import { forcedThemeClass, type EditorThemeSetting } from '../shared/editorTheme';
 import { installBlankLineLexerNormalizer } from './utils/markedLexerNormalizer';
 import {
   setupImageDragDrop,
@@ -1751,6 +1752,13 @@ window.addEventListener('openExtensionSettings', () => {
   vscode.postMessage({ type: 'openExtensionSettings' });
 });
 
+// Handle theme toggle button from toolbar -> flip the global editorTheme setting.
+// The extension computes the opposite of the currently effective theme and
+// writes it back, which re-themes every open editor via settingsUpdate.
+window.addEventListener('toggleTheme', () => {
+  vscode.postMessage({ type: 'toggleTheme' });
+});
+
 // Zoom: applies zoom level from markdownForHumans.zoom setting (percentage, 100 = default).
 // We use a CSS calc() expression so the override stays live — if the user later changes
 // their VS Code editor font size, --md-base-size-override recomputes automatically
@@ -1766,9 +1774,21 @@ function applyZoomLevel(percent: number) {
     );
   }
 }
+// Forces the editor into a fixed light/dark palette regardless of the active
+// VS Code theme by toggling a body class that overrides the --vscode-* tokens
+// the editor consumes (see editor.css). 'vscode' applies no class so VS Code's
+// own theme drives the appearance, exactly as before this setting existed.
+function applyThemeOverride(setting: EditorThemeSetting) {
+  const forced = forcedThemeClass(setting);
+  document.body.classList.remove('mdfh-force-light', 'mdfh-force-dark');
+  if (forced) {
+    document.body.classList.add(forced);
+  }
+}
+
 /**
- * Applies paragraph spacing and zoom settings from an incoming message.
- * Called from both the `update` and `settingsUpdate` handlers.
+ * Applies paragraph spacing, zoom, and theme-override settings from an incoming
+ * message. Called from both the `update` and `settingsUpdate` handlers.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function applyEditorSettings(message: Record<string, any>) {
@@ -1786,6 +1806,13 @@ function applyEditorSettings(message: Record<string, any>) {
   }
   if (typeof message.zoom === 'number') {
     applyZoomLevel(message.zoom);
+  }
+  if (
+    message.editorTheme === 'vscode' ||
+    message.editorTheme === 'defaultLight' ||
+    message.editorTheme === 'defaultDark'
+  ) {
+    applyThemeOverride(message.editorTheme);
   }
 }
 

--- a/src/webview/editor.ts
+++ b/src/webview/editor.ts
@@ -33,7 +33,7 @@ import { DocumentAuditExtension } from './features/auditDocument';
 import { createFormattingToolbar, createTableMenu, updateToolbarStates } from './BubbleMenuView';
 import { getEditorMarkdownForSync } from './utils/markdownSerialization';
 import type { BlankLineMode } from '../shared/blankLinePolicy';
-import { forcedThemeClass, type EditorThemeSetting } from '../shared/editorTheme';
+import { overrideClassFor, type EditorThemeSetting } from '../shared/editorTheme';
 import { installBlankLineLexerNormalizer } from './utils/markedLexerNormalizer';
 import {
   setupImageDragDrop,
@@ -1774,16 +1774,59 @@ function applyZoomLevel(percent: number) {
     );
   }
 }
-// Forces the editor into a fixed light/dark palette regardless of the active
-// VS Code theme by toggling a body class that overrides the --vscode-* tokens
-// the editor consumes (see editor.css). 'vscode' applies no class so VS Code's
-// own theme drives the appearance, exactly as before this setting existed.
-function applyThemeOverride(setting: EditorThemeSetting) {
-  const forced = forcedThemeClass(setting);
-  document.body.classList.remove('mdfh-force-light', 'mdfh-force-dark');
-  if (forced) {
-    document.body.classList.add(forced);
+// Editor theme override.
+//
+// When the requested direction already matches VS Code's active appearance, no
+// class is added and the editor inherits the real live theme (so "Always dark"
+// on a dark VS Code looks exactly like the user's actual dark theme); the
+// synthetic palette is applied only when forcing the opposite direction.
+// 'vscode' always inherits.
+//
+// The class goes on BOTH <html> and <body>:
+//  - <body> carries the --vscode-* variable overrides (they win there via
+//    inheritance; VS Code sets those vars inline on <html>, so a class rule on
+//    <html> could not override them) and satisfies the syntax-highlight guards
+//    (.vscode-dark:not(.mdfh-force-light)) that key off the body class.
+//  - <html> paints the overscroll/page background with a literal color so the
+//    area around the editor matches (see editor.css).
+//
+// Self-healing: VS Code reassigns body.className (not classList.add) during its
+// theme handshake, which can wipe our class right after the first apply. A
+// MutationObserver re-asserts the desired state whenever the class attribute
+// changes. reconcile only mutates when out of sync, so it settles in one pass
+// and cannot loop.
+let lastThemeSetting: EditorThemeSetting = 'vscode';
+let lastVscodeIsDark = false;
+let themeClassObserver: MutationObserver | null = null;
+
+function reconcileThemeClasses() {
+  const forced = overrideClassFor(lastThemeSetting, lastVscodeIsDark);
+  for (const el of [document.documentElement, document.body]) {
+    if (!el) continue;
+    const wantLight = forced === 'mdfh-force-light';
+    const wantDark = forced === 'mdfh-force-dark';
+    if (el.classList.contains('mdfh-force-light') !== wantLight) {
+      el.classList.toggle('mdfh-force-light', wantLight);
+    }
+    if (el.classList.contains('mdfh-force-dark') !== wantDark) {
+      el.classList.toggle('mdfh-force-dark', wantDark);
+    }
   }
+}
+
+function ensureThemeClassObserver() {
+  if (themeClassObserver) return;
+  themeClassObserver = new MutationObserver(() => reconcileThemeClasses());
+  const opts: MutationObserverInit = { attributes: true, attributeFilter: ['class'] };
+  themeClassObserver.observe(document.documentElement, opts);
+  themeClassObserver.observe(document.body, opts);
+}
+
+function applyThemeOverride(setting: EditorThemeSetting, vscodeIsDark: boolean) {
+  lastThemeSetting = setting;
+  lastVscodeIsDark = vscodeIsDark;
+  reconcileThemeClasses();
+  ensureThemeClassObserver();
 }
 
 /**
@@ -1812,7 +1855,14 @@ function applyEditorSettings(message: Record<string, any>) {
     message.editorTheme === 'defaultLight' ||
     message.editorTheme === 'defaultDark'
   ) {
-    applyThemeOverride(message.editorTheme);
+    // The extension reports VS Code's current appearance; fall back to the body
+    // class if an older message omits it.
+    const vscodeIsDark =
+      typeof message.vscodeIsDark === 'boolean'
+        ? message.vscodeIsDark
+        : document.body.classList.contains('vscode-dark') ||
+          document.body.classList.contains('vscode-high-contrast');
+    applyThemeOverride(message.editorTheme, vscodeIsDark);
   }
 }
 


### PR DESCRIPTION
## Summary

Adds the ability to set the Markdown for Humans editor's color theme independently of the rest of VS Code, via a new setting and a quick toolbar toggle.

- **Setting** `markdownForHumans.display.editorTheme` (scope: application): `Follow VS Code theme` (default), `Always use a light theme`, `Always use a dark theme`.
- **Toolbar toggle** (`color-mode` icon, at the end of the toolbar to the right of the gear): flips between light and dark. It writes the opposite of the currently effective appearance to the global setting, so the change applies to all open editors at once.

### Editor Toggle button
<img width="948" height="490" alt="image" src="https://github.com/user-attachments/assets/15d5b74f-a68b-41aa-8c91-5960c7026d66" />
<img width="948" height="490" alt="image" src="https://github.com/user-attachments/assets/dbe297a1-6a0e-4c1a-9839-49fb295a9929" />

### Extension Settings
<img width="806" height="286" alt="image" src="https://github.com/user-attachments/assets/0135bc6b-dc06-4822-8ad4-3d6f1296d674" />


## Behavior

When the requested direction already matches VS Code's active appearance, the editor **inherits your real VS Code theme** (best fidelity). The built-in light/dark palette is used **only when forcing the opposite** of the active appearance (for example a light editor while VS Code is dark). `Follow VS Code theme` always inherits.

| VS Code theme | Setting | Result |
|---|---|---|
| Dark | Always dark | Your actual dark theme (inherited) |
| Light | Always light | Your actual light theme (inherited) |
| Dark | Always light | Built-in light palette |
| Light | Always dark | Built-in dark palette |
| any | Follow VS Code | Your actual theme |

The forced appearance also follows VS Code live: switching your VS Code theme re-evaluates the editor automatically.

## How it works

- Pure, unit-tested decision helpers in `src/shared/editorTheme.ts` (`appearanceFromKind`, `effectiveAppearance`, `resolveToggleTarget`, `overrideClassFor`).
- The provider flows the setting and VS Code's current appearance (`vscodeIsDark`) to the webview (`update` / `ready` / `settingsUpdate`), handles the `toggleTheme` message by writing the opposite of the effective appearance to global config, and re-broadcasts on `onDidChangeActiveColorTheme`. Each open panel's own `onDidChangeConfiguration` subscription re-themes it, so the toggle reaches every editor without extra broadcast code.
- The webview applies `.mdfh-force-light` / `.mdfh-force-dark` on `<body>` (the `--vscode-*` overrides win there via inheritance; VS Code sets those vars inline on `<html>`) and `<html>` (page/overscroll background). A `MutationObserver` re-asserts the class when VS Code reassigns `body.className` during its theme handshake, so the override applies on the first load.
- Self-contained light/dark palettes live in `editor.css`; the dark syntax-highlight rules are guarded so code blocks render correctly when forcing a theme opposite to VS Code's.

## Testing

- 17 new unit tests for the pure helpers (TDD); full suite **875 passing**.
- `npm run build:release` + `npm run verify-build` pass; `toggleTheme` and `.mdfh-force-dark` are registered as tree-shake guards.

## Screenshots / recording

_To be added._

## Notes

- No version bump is included; versioning is left to the maintainers.
- Lint: this branch reports CRLF errors under `npm run lint` only because of a CRLF working-tree checkout vs Prettier's LF expectation. This is pre-existing and repo-wide (untouched files included); the changed files have no other lint issues, so `lint:fix` was intentionally not run (it would rewrite every file).
- Plan: `roadmap/pipeline/task-editor-theme-override.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
