### PR TITLE
Add copy button to code blocks

### DIFF
--- a/src/__tests__/webview/codeBlockWithCopy.test.ts
+++ b/src/__tests__/webview/codeBlockWithCopy.test.ts
@@ -1,0 +1,132 @@
+/** @jest-environment jsdom */
+
+import { Schema } from '@tiptap/pm/model';
+import { createCodeBlockCopyNodeView } from '../../webview/extensions/codeBlockCopyNodeView';
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: 'codeBlock+' },
+    text: { group: 'inline' },
+    codeBlock: {
+      content: 'text*',
+      group: 'block',
+      code: true,
+      defining: true,
+      attrs: {
+        language: { default: null },
+        'indent-prefix': { default: null },
+      },
+    },
+  },
+});
+
+function createNodeView(code = 'npm run build\nnpm test', language = 'bash') {
+  const node = schema.nodes.codeBlock.create(
+    { language, 'indent-prefix': null },
+    schema.text(code)
+  );
+
+  return createCodeBlockCopyNodeView(node, {
+    class: 'code-block-highlighted',
+  });
+}
+
+describe('CodeBlockWithCopy node view', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('keeps code editable through contentDOM and renders a non-editable copy button', () => {
+    const nodeView = createNodeView();
+    const wrapper = nodeView.dom as HTMLElement;
+    const pre = wrapper.querySelector('pre');
+    const button = wrapper.querySelector('button');
+    const icon = button?.querySelector('.codicon');
+    const tooltip = wrapper.querySelector('[role="status"]');
+
+    expect(wrapper.classList.contains('code-block-wrapper')).toBe(true);
+    expect(pre?.classList.contains('code-block-highlighted')).toBe(true);
+    expect(nodeView.contentDOM).toBe(wrapper.querySelector('code'));
+    expect(icon?.classList.contains('codicon-copy')).toBe(true);
+    expect(button?.getAttribute('contenteditable')).toBe('false');
+    expect(button?.getAttribute('aria-label')).toBe('Copy code block');
+    expect(button?.getAttribute('title')).toBe('Copy code block');
+    expect(tooltip?.getAttribute('aria-live')).toBe('polite');
+    expect(tooltip?.textContent).toBe('');
+  });
+
+  it('copies only raw node text and shows temporary success feedback', async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+    const nodeView = createNodeView('echo "hello"\nexit 0', 'shell');
+    const wrapper = nodeView.dom as HTMLElement;
+    const button = (nodeView.dom as HTMLElement).querySelector('button') as HTMLButtonElement;
+    const icon = button.querySelector('.codicon') as HTMLElement;
+    const tooltip = wrapper.querySelector('[role="status"]') as HTMLElement;
+
+    button.click();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(writeText).toHaveBeenCalledWith('echo "hello"\nexit 0');
+    expect(button.classList.contains('is-copied')).toBe(true);
+    expect(icon.classList.contains('codicon-check')).toBe(true);
+    expect(icon.classList.contains('codicon-copy')).toBe(false);
+    expect(button.getAttribute('aria-label')).toBe('Code block copied');
+    expect(tooltip.classList.contains('visible')).toBe(true);
+    expect(tooltip.textContent).toBe('Copied!');
+
+    jest.advanceTimersByTime(1600);
+    expect(button.classList.contains('is-copied')).toBe(false);
+    expect(icon.classList.contains('codicon-copy')).toBe(true);
+    expect(tooltip.classList.contains('visible')).toBe(false);
+    expect(tooltip.textContent).toBe('');
+  });
+
+  it('prevents mouse interaction from moving focus into the editor', () => {
+    const nodeView = createNodeView();
+    const button = (nodeView.dom as HTMLElement).querySelector('button') as HTMLButtonElement;
+    const mouseDown = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
+
+    button.dispatchEvent(mouseDown);
+
+    expect(mouseDown.defaultPrevented).toBe(true);
+    expect(nodeView.stopEvent?.(mouseDown)).toBe(true);
+  });
+
+  it('falls back to execCommand when navigator.clipboard rejects', async () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const writeText = jest.fn().mockRejectedValue(new Error('clipboard blocked'));
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+    const execCommand = jest.fn().mockReturnValue(true);
+    Object.defineProperty(document, 'execCommand', {
+      configurable: true,
+      value: execCommand,
+    });
+    const nodeView = createNodeView('raw code');
+    const button = (nodeView.dom as HTMLElement).querySelector('button') as HTMLButtonElement;
+    const previousFocus = document.createElement('input');
+    document.body.appendChild(previousFocus);
+    previousFocus.focus();
+
+    button.click();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(execCommand).toHaveBeenCalledWith('copy');
+    expect(button.classList.contains('is-copied')).toBe(true);
+    expect(document.querySelector('.code-block-copy-fallback')).toBeNull();
+    expect(document.activeElement).toBe(previousFocus);
+  });
+});

--- a/src/__tests__/webview/undo-sync.test.ts
+++ b/src/__tests__/webview/undo-sync.test.ts
@@ -41,6 +41,9 @@ jest.mock('@tiptap/extension-code-block-lowlight', () => ({
   __esModule: true,
   default: { configure: () => ({}) },
 }));
+jest.mock('./../../webview/extensions/codeBlockWithCopy', () => ({
+  CodeBlockWithCopy: { configure: () => ({}) },
+}));
 jest.mock('./../../webview/extensions/customImage', () => ({
   CustomImage: { configure: () => ({}) },
 }));

--- a/src/webview/editor.css
+++ b/src/webview/editor.css
@@ -239,6 +239,95 @@
     line-height: 1.5;
     overflow-x: auto;
   }
+
+  .code-block-wrapper {
+    position: relative;
+    margin: 1em 0;
+  }
+
+  .code-block-wrapper .code-block-highlighted {
+    margin: 0;
+    padding-right: 60px;
+  }
+
+  .code-block-copy-button {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    z-index: 2;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    padding: 0;
+    border: 1px solid var(--vscode-editorWidget-border, var(--md-border));
+    border-radius: 6px;
+    background-color: var(--vscode-editorWidget-background, var(--vscode-editor-background));
+    color: var(--vscode-editorWidget-foreground, var(--md-foreground));
+    cursor: pointer;
+    opacity: 0.8;
+    user-select: none;
+    transition: background-color 0.15s ease, color 0.15s ease, opacity 0.15s ease;
+  }
+
+  .code-block-copy-button:hover {
+    background-color: var(--vscode-list-hoverBackground);
+    opacity: 1;
+  }
+
+  .code-block-copy-button:focus-visible {
+    outline: 1px solid var(--vscode-focusBorder);
+    outline-offset: 2px;
+    opacity: 1;
+  }
+
+  .code-block-copy-button:active {
+    background-color: var(--vscode-list-activeSelectionBackground);
+  }
+
+  .code-block-copy-button .codicon {
+    font-size: 18px;
+  }
+
+  .code-block-copy-button.is-copied {
+    color: var(--vscode-testing-iconPassed, var(--vscode-charts-green));
+    opacity: 1;
+  }
+
+  .code-block-copy-tooltip {
+    position: absolute;
+    top: 8px;
+    right: 48px;
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    min-height: 32px;
+    padding: 0 12px;
+    border: 1px solid var(--vscode-editorWidget-border, var(--md-border));
+    border-radius: 6px;
+    background-color: var(--vscode-editorWidget-background, var(--vscode-editor-background));
+    color: var(--vscode-editorWidget-foreground, var(--md-foreground));
+    font-family: var(--vscode-font-family);
+    font-size: 12px;
+    line-height: 1;
+    white-space: nowrap;
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transform: translateX(4px);
+    transition: opacity 0.15s ease, transform 0.15s ease, visibility 0.15s ease;
+  }
+
+  .code-block-copy-tooltip.visible {
+    opacity: 1;
+    visibility: visible;
+    transform: translateX(0);
+  }
+
+  .code-block-copy-tooltip.is-error {
+    color: var(--vscode-errorForeground);
+  }
   
   /* ============================================
      Syntax Highlighting - GitHub Theme (Light)

--- a/src/webview/editor.ts
+++ b/src/webview/editor.ts
@@ -14,12 +14,11 @@ import { Markdown } from '@tiptap/markdown';
 import { TableCell, TableHeader, TableRow } from '@tiptap/extension-table';
 import { ListKit } from '@tiptap/extension-list';
 import Link from '@tiptap/extension-link';
-import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight';
 import { CustomImage } from './extensions/customImage';
 import { lowlight } from 'lowlight';
 import { Mermaid } from './extensions/mermaid';
 import { IndentedImageCodeBlock } from './extensions/indentedImageCodeBlock';
-import { parsePreservedCodeBlock, renderPreservedCodeBlock } from './extensions/preservedCodeBlock';
+import { CodeBlockWithCopy } from './extensions/codeBlockWithCopy';
 import { SpaceFriendlyImagePaths } from './extensions/spaceFriendlyImagePaths';
 import { TabIndentation } from './extensions/tabIndentation';
 import { GitHubAlerts } from './extensions/githubAlerts';
@@ -539,26 +538,7 @@ function initializeEditor(initialContent: string) {
           },
         }),
         MarkdownParagraph, // Custom paragraph with empty-paragraph filtering in renderMarkdown
-        CodeBlockLowlight.extend({
-          addAttributes() {
-            return {
-              ...this.parent?.(),
-              'indent-prefix': {
-                default: null,
-                parseHTML: element => element.getAttribute('data-indent-prefix'),
-                renderHTML: attributes => {
-                  const prefix = attributes['indent-prefix'];
-                  if (typeof prefix !== 'string' || prefix.length === 0) {
-                    return {};
-                  }
-                  return { 'data-indent-prefix': prefix };
-                },
-              },
-            };
-          },
-          parseMarkdown: parsePreservedCodeBlock,
-          renderMarkdown: renderPreservedCodeBlock,
-        }).configure({
+        CodeBlockWithCopy.configure({
           lowlight,
           HTMLAttributes: {
             class: 'code-block-highlighted',

--- a/src/webview/extensions/codeBlockCopyNodeView.ts
+++ b/src/webview/extensions/codeBlockCopyNodeView.ts
@@ -1,0 +1,185 @@
+/**
+ * Copyright (c) 2025-2026 Concret.io
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for details.
+ */
+
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model';
+import type { NodeView } from '@tiptap/pm/view';
+
+const COPY_FEEDBACK_MS = 1500;
+
+type CodeBlockHtmlAttributes = Record<string, unknown>;
+
+function applyHtmlAttributes(element: HTMLElement, attributes: CodeBlockHtmlAttributes): void {
+  Object.entries(attributes).forEach(([name, value]) => {
+    if (value === null || value === undefined || value === false) {
+      return;
+    }
+    element.setAttribute(name, String(value));
+  });
+}
+
+function copyWithExecCommand(text: string): boolean {
+  if (typeof document.execCommand !== 'function') {
+    return false;
+  }
+
+  const previousFocus = document.activeElement;
+  const selection = window.getSelection();
+  const previousRanges =
+    selection === null
+      ? []
+      : Array.from({ length: selection.rangeCount }, (_, index) => selection.getRangeAt(index));
+  const textarea = document.createElement('textarea');
+  textarea.className = 'code-block-copy-fallback';
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'fixed';
+  textarea.style.opacity = '0';
+  document.body.appendChild(textarea);
+  textarea.select();
+
+  try {
+    return document.execCommand('copy');
+  } finally {
+    textarea.remove();
+    selection?.removeAllRanges();
+    previousRanges.forEach(range => selection?.addRange(range));
+    if (previousFocus instanceof HTMLElement) {
+      previousFocus.focus({ preventScroll: true });
+    }
+  }
+}
+
+async function copyCodeText(text: string): Promise<boolean> {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch (error) {
+    console.warn('[MD4H] Clipboard API unavailable, using copy fallback:', error);
+  }
+
+  return copyWithExecCommand(text);
+}
+
+/**
+ * Creates a ProseMirror node view that keeps code editable while placing the
+ * copy control outside the managed content DOM.
+ */
+export function createCodeBlockCopyNodeView(
+  initialNode: ProseMirrorNode,
+  htmlAttributes: CodeBlockHtmlAttributes,
+  languageClassPrefix = 'language-'
+): NodeView {
+  let currentNode = initialNode;
+  let feedbackTimer: number | null = null;
+
+  const wrapper = document.createElement('div');
+  wrapper.className = 'code-block-wrapper';
+
+  const pre = document.createElement('pre');
+  applyHtmlAttributes(pre, htmlAttributes);
+
+  const code = document.createElement('code');
+  const updateLanguageClass = (node: ProseMirrorNode): void => {
+    const language = typeof node.attrs.language === 'string' ? node.attrs.language : '';
+    code.className = language ? `${languageClassPrefix}${language}` : '';
+  };
+  updateLanguageClass(currentNode);
+
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'code-block-copy-button';
+  button.contentEditable = 'false';
+  button.setAttribute('contenteditable', 'false');
+  button.title = 'Copy code block';
+  button.setAttribute('aria-label', 'Copy code block');
+
+  const icon = document.createElement('span');
+  icon.className = 'codicon codicon-copy';
+  icon.setAttribute('aria-hidden', 'true');
+  button.appendChild(icon);
+
+  const tooltip = document.createElement('span');
+  tooltip.className = 'code-block-copy-tooltip';
+  tooltip.contentEditable = 'false';
+  tooltip.setAttribute('contenteditable', 'false');
+  tooltip.setAttribute('role', 'status');
+  tooltip.setAttribute('aria-live', 'polite');
+
+  const setCopyState = (copied: boolean): void => {
+    button.classList.toggle('is-copied', copied);
+    icon.classList.toggle('codicon-copy', !copied);
+    icon.classList.toggle('codicon-check', copied);
+    tooltip.classList.toggle('visible', copied);
+    tooltip.textContent = copied ? 'Copied!' : '';
+    button.setAttribute('aria-label', copied ? 'Code block copied' : 'Copy code block');
+  };
+
+  button.addEventListener('mousedown', event => {
+    // Keep the current editor selection and focus unchanged for mouse users.
+    event.preventDefault();
+    event.stopPropagation();
+  });
+
+  button.addEventListener('click', event => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    void copyCodeText(currentNode.textContent)
+      .then(copied => {
+        if (copied) {
+          setCopyState(true);
+        } else {
+          button.classList.remove('is-copied');
+          icon.className = 'codicon codicon-copy';
+          tooltip.classList.add('visible', 'is-error');
+          tooltip.textContent = 'Copy failed';
+          button.setAttribute('aria-label', 'Could not copy code block');
+        }
+
+        if (feedbackTimer !== null) {
+          window.clearTimeout(feedbackTimer);
+        }
+        feedbackTimer = window.setTimeout(() => {
+          setCopyState(false);
+          tooltip.classList.remove('is-error');
+          feedbackTimer = null;
+        }, COPY_FEEDBACK_MS);
+      })
+      .catch(error => {
+        console.error('[MD4H] Failed to copy code block:', error);
+      });
+  });
+
+  pre.appendChild(code);
+  wrapper.appendChild(pre);
+  wrapper.appendChild(tooltip);
+  wrapper.appendChild(button);
+
+  return {
+    dom: wrapper,
+    contentDOM: code,
+    update: updatedNode => {
+      if (updatedNode.type !== currentNode.type) {
+        return false;
+      }
+
+      currentNode = updatedNode;
+      updateLanguageClass(currentNode);
+      return true;
+    },
+    stopEvent: event =>
+      button.contains(event.target as globalThis.Node) ||
+      tooltip.contains(event.target as globalThis.Node),
+    ignoreMutation: mutation => !code.contains(mutation.target) && mutation.target !== code,
+    destroy: () => {
+      if (feedbackTimer !== null) {
+        window.clearTimeout(feedbackTimer);
+      }
+    },
+  };
+}

--- a/src/webview/extensions/codeBlockWithCopy.ts
+++ b/src/webview/extensions/codeBlockWithCopy.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2025-2026 Concret.io
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for details.
+ */
+
+import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight';
+import { parsePreservedCodeBlock, renderPreservedCodeBlock } from './preservedCodeBlock';
+import { createCodeBlockCopyNodeView } from './codeBlockCopyNodeView';
+
+/**
+ * Syntax-highlighted code block with preserved Markdown indentation and a
+ * ProseMirror-safe copy control.
+ */
+export const CodeBlockWithCopy = CodeBlockLowlight.extend({
+  addAttributes() {
+    return {
+      ...this.parent?.(),
+      'indent-prefix': {
+        default: null,
+        parseHTML: element => element.getAttribute('data-indent-prefix'),
+        renderHTML: attributes => {
+          const prefix = attributes['indent-prefix'];
+          if (typeof prefix !== 'string' || prefix.length === 0) {
+            return {};
+          }
+          return { 'data-indent-prefix': prefix };
+        },
+      },
+    };
+  },
+
+  addNodeView() {
+    return ({ node, HTMLAttributes, extension }) =>
+      createCodeBlockCopyNodeView(
+        node,
+        HTMLAttributes,
+        extension.options.languageClassPrefix as string
+      );
+  },
+
+  parseMarkdown: parsePreservedCodeBlock,
+  renderMarkdown: renderPreservedCodeBlock,
+});


### PR DESCRIPTION
## Description

Adds a copy-to-clipboard button to rendered code blocks in the Markdown for Humans editor.

The button copies only the raw code block content, excluding Markdown fences and language labels, and shows temporary feedback after copying.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/modification

## Related Issues

Fixes #28

## Changes Made

- Added a TipTap code block extension with a copy-to-clipboard node view.
- Added copy/copy-success/error UI styling for code blocks.
- Added tests covering the copyable code block extension and updated related undo/sync coverage.

## Screen Recording / Visual Demo

- [ ] I have included a screen recording showing the **before** state (if fixing a bug)
- [ ] I have included a screen recording showing the **after** state (the fix/feature working)
- [ ] Screen recording uploaded to [Loom.com](https://www.loom.com) or similar (paste link below)

**Screen Recording Link:** <!-- Paste link here -->

**Screenshots (if applicable):**
<img width="405" height="221" alt="image" src="https://github.com/user-attachments/assets/254e0cc4-7bf8-4b1d-be68-33834b5ac9b8" /> <img width="359" height="221" alt="image" src="https://github.com/user-attachments/assets/10e8be10-d03e-4a89-8546-85038a0fa9c0" />

## Testing

- [x] All existing tests pass (`npm test`)
- [ ] Linting passes with no errors (`npm run lint:fix`)
- [ ] Build succeeds (`npm run build:release`)
- [ ] Extension can be packaged (`npm run package:release`)
- [x] Manually tested in VS Code Extension Development Host
- [ ] Tested with both saved files (`file:`) and untitled files (`untitled:`)
- [ ] Tested in light and dark themes
- [ ] Tested with large documents (1000+ lines) if applicable

### Test Environment

- OS: Windows 11
- VS Code Version: 1.123.0
- Node Version: 24.15.0

## Documentation

- [ ] Updated README.md (if needed)
- [ ] Updated CHANGELOG.md
- [ ] Added/updated code comments
- [ ] Updated documentation in `/docs` (if needed)

## Checklist

- [x] My code follows the project's coding standards (see `CONTRIBUTING.md` and `vibe-coding-rules/`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Error handling is implemented for async operations (see `vibe-coding-rules/coding-standards.md`)
- [x] No `console.log` statements added (or they're properly conditional for debug mode)
- [ ] Any dependent changes have been merged and published
- [ ] I have read and followed the TDD workflow if this is a new feature (write tests first)

## Additional Notes

`npm test` passes locally:

- Test Suites: 1 skipped, 64 passed, 64 of 65 total
- Tests: 27 skipped, 121 todo, 862 passed, 1010 total

`npm run build:debug` also succeeds locally.

I did not run `npm run lint:fix` because it may apply unrelated formatting changes across the repository.