### PR TITLE
fix: prevent frontmatter data loss when a YAML value contains a ``` fence

### DIFF
--- a/src/__tests__/editor/frontmatterRendering.test.ts
+++ b/src/__tests__/editor/frontmatterRendering.test.ts
@@ -82,3 +82,132 @@ describe('MarkdownEditorProvider frontmatter rendering', () => {
     expect(savedText).toContain('\n---\n\n# Heading');
   });
 });
+
+// ===========================================================================
+// Regression: frontmatter whose value contains a ``` fence was corrupted on
+// round-trip. The host wrapped with a fixed 3-backtick fence, so the embedded
+// ``` closed the fence early in the webview's markdown parser, fragmenting the
+// frontmatter and dropping fields. The fix lengthens the wrapper fence to be
+// longer than any backtick run inside the frontmatter (CommonMark then forbids
+// the inner run from closing it) and teaches the unwrapper to accept the longer
+// fence. See: QA finding FM-19, .concret.io/goal/qa-adversarial-ai-ctx/.
+//
+// Why these tests assert the two halves (fence length on wrap; recognition on
+// unwrap) rather than a full editor round-trip: the corruption is introduced by
+// the marked parser between wrap (host/Node) and unwrap (host/Node), and the
+// parser runs in the webview (jsdom). A pure host wrap→unwrap is textually
+// symmetric and would pass even with the bug. The invariant "wrapped fence is
+// longer than every inner backtick run" is exactly what stops the parser from
+// splitting the block, so it is the precise property to pin.
+describe('MarkdownEditorProvider frontmatter with embedded code fences', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  /** Longest run of consecutive backticks anywhere in `s` (0 if none). */
+  function longestBacktickRun(s: string): number {
+    const runs = s.match(/`+/g);
+    return runs ? Math.max(...runs.map(r => r.length)) : 0;
+  }
+
+  it('wraps with a fence longer than any backtick run inside the frontmatter', () => {
+    const provider = new MarkdownEditorProvider({} as ExtensionContext);
+    // A multiline YAML scalar holding a fenced code sample — contains ```.
+    const content = [
+      '---',
+      'title: Example',
+      'snippet: |',
+      '  ```',
+      '  code()',
+      '  ```',
+      'slug: example',
+      '---',
+      '',
+      '# Heading',
+    ].join('\n');
+
+    const document = createDocument(content);
+    const webview = { postMessage: jest.fn() };
+    (
+      provider as unknown as {
+        updateWebview: (doc: TextDocument, wv: { postMessage: jest.Mock }) => void;
+      }
+    ).updateWebview(document as unknown as TextDocument, webview);
+
+    const wrapped = (webview.postMessage as jest.Mock).mock.calls[0][0].content as string;
+    const openingFence = wrapped.split('\n')[0].replace(/yaml$/i, '');
+    // The opening fence must be strictly longer than the embedded ``` (3), so the
+    // webview parser cannot treat the inner run as a closing fence.
+    expect(openingFence.length).toBeGreaterThan(longestBacktickRun('```\ncode()\n```'));
+    expect(/^`{4,}yaml$/.test(wrapped.split('\n')[0])).toBe(true);
+    // The frontmatter fields must all still be inside the single wrapped block.
+    expect(wrapped).toContain('title: Example');
+    expect(wrapped).toContain('slug: example');
+  });
+
+  it('restores YAML delimiters when saving a block fenced with 4+ backticks', async () => {
+    const provider = new MarkdownEditorProvider({} as ExtensionContext);
+    const original = ['---', 'title: Old', 'slug: s', '---', '', '# Heading'].join('\n');
+    const document = createDocument(original) as unknown as TextDocument;
+    const webview = { postMessage: jest.fn() };
+    (
+      provider as unknown as {
+        updateWebview: (doc: TextDocument, wv: { postMessage: jest.Mock }) => void;
+      }
+    ).updateWebview(document, webview);
+
+    // What the webview serializes back when the frontmatter contains a ``` run:
+    // prosemirror-markdown emits a fence one longer than the inner run (````).
+    const editedFenced = [
+      '````yaml',
+      '---',
+      'title: New',
+      'snippet: |',
+      '  ```',
+      '  code()',
+      '  ```',
+      'slug: s',
+      '---',
+      '````',
+      '',
+      '# Heading',
+    ].join('\n');
+
+    let savedText = '';
+    (workspace.applyEdit as jest.Mock).mockImplementation(async (edit: WorkspaceEdit) => {
+      const replaces = (edit as unknown as { replaces?: Array<{ text: string }> }).replaces || [];
+      if (replaces.length > 0) {
+        savedText = replaces[0].text;
+      }
+      return true;
+    });
+
+    await (
+      provider as unknown as { applyEdit: (content: string, doc: TextDocument) => Promise<void> }
+    ).applyEdit(editedFenced, document);
+
+    // The ````-fenced block must unwrap back to plain --- frontmatter, and NO
+    // field may be lost. Before the fix, unwrap only recognized exactly ```yaml,
+    // so the ````yaml block was left intact (corruption: a code block on disk).
+    expect(savedText.startsWith('---\ntitle: New')).toBe(true);
+    expect(savedText).toContain('slug: s'); // field survives — no data loss
+    expect(savedText).toContain('\n---\n\n# Heading');
+    expect(savedText).not.toContain('````'); // the wrapper fence is gone
+  });
+
+  it('does NOT lengthen the fence for ordinary frontmatter (no behavior change)', () => {
+    const provider = new MarkdownEditorProvider({} as ExtensionContext);
+    const content = ['---', 'title: Plain', '---', '', '# Heading'].join('\n');
+    const document = createDocument(content);
+    const webview = { postMessage: jest.fn() };
+    (
+      provider as unknown as {
+        updateWebview: (doc: TextDocument, wv: { postMessage: jest.Mock }) => void;
+      }
+    ).updateWebview(document as unknown as TextDocument, webview);
+
+    const wrapped = (webview.postMessage as jest.Mock).mock.calls[0][0].content as string;
+    // Ordinary frontmatter (no backticks) must still use exactly ```yaml.
+    expect(wrapped.split('\n')[0]).toBe('```yaml');
+  });
+});

--- a/src/editor/MarkdownEditorProvider.ts
+++ b/src/editor/MarkdownEditorProvider.ts
@@ -3471,7 +3471,20 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
     const frontmatterBlock = match[0].replace(/\s+$/, ''); // keep delimiters
     const body = content.slice(match[0].length);
 
-    const pieces = ['```yaml', frontmatterBlock, '```'];
+    // Choose a fence longer than the longest backtick run inside the
+    // frontmatter. If a YAML value contains a ``` (e.g. a fenced code sample in
+    // a multiline scalar), a plain 3-backtick fence would be closed early by the
+    // webview's markdown parser, fragmenting the frontmatter and losing fields
+    // on save. CommonMark requires the closing fence to be at least as long as
+    // the opening one, so a longer fence keeps the whole block intact. Mirrors
+    // prosemirror-markdown's own code_block fence logic so a re-serialized block
+    // round-trips through unwrapFrontmatterFromWebview.
+    const backtickRuns = frontmatterBlock.match(/`{3,}/g);
+    const fence = backtickRuns
+      ? '`'.repeat(Math.max(...backtickRuns.map(run => run.length)) + 1)
+      : '```';
+
+    const pieces = [`${fence}yaml`, frontmatterBlock, fence];
     if (body.length > 0) {
       // Ensure exactly one blank line between fenced block and body
       const trimmedBody =
@@ -3493,12 +3506,19 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
     const newline = usesCrLf ? '\r\n' : '\n';
     const lines = content.split(newline);
 
-    const firstLine = lines[0].trim().toLowerCase();
-    if (firstLine !== '```yaml' && firstLine !== '```yml' && firstLine !== '```json') {
+    // Accept a fence of 3+ backticks: wrapFrontmatterForWebview lengthens it when
+    // the frontmatter contains an embedded ``` run, and prosemirror-markdown does
+    // the same on re-serialize. The closing fence must match the opener's length.
+    const fenceMatch = lines[0]
+      .trim()
+      .toLowerCase()
+      .match(/^(`{3,})(yaml|yml|json)$/);
+    if (!fenceMatch) {
       return content;
     }
+    const fence = fenceMatch[1];
 
-    const closingIndex = lines.findIndex((line, idx) => idx > 0 && line.trim() === '```');
+    const closingIndex = lines.findIndex((line, idx) => idx > 0 && line.trim() === fence);
     if (closingIndex === -1) return content;
 
     const insideLines = lines.slice(1, closingIndex);


### PR DESCRIPTION
## TL;DR

A markdown file whose **YAML frontmatter contains a triple-backtick code fence** (e.g. a fenced code sample inside a multiline scalar) is **silently corrupted on round-trip**: fields are dropped and code leaks into the document body. This PR fixes the host's frontmatter wrap/unwrap so the embedded fence can no longer break the block, and adds red→green regression tests.

## How this was found

While running an adversarial QA pass on the (separate) "Copy as AI Context" line-number fix, one fixture stress-tested frontmatter containing an embedded ` ``` ` fence (QA fixture **FM-19**). It surfaced a bug that has nothing to do with line numbers and everything to do with how frontmatter is shuttled to the webview.

## The bug

To render YAML frontmatter as an editable code block, the host wraps it in a fence before sending it to the webview (`wrapFrontmatterForWebview`) and strips that fence back off on save (`unwrapFrontmatterFromWebview`). The wrap used a **hard-coded 3-backtick fence**:

```ts
const pieces = ['```yaml', frontmatterBlock, '```'];
```

When the frontmatter value itself contains a ` ``` ` run, the webview's markdown parser (marked / prosemirror-markdown) obeys CommonMark and treats the **first** ` ``` ` it sees as the closing fence — which is the *inner* one. The frontmatter block is split apart.

### Reproduction

On-disk file:

````markdown
---
example: |
  ```
  code
  ```
title: x
---

# After Embedded Fence
````

Observed parse (verified in a jsdom editor with the production extension set):

```
codeBlock("---\nexample: |")     ← truncated at the inner ```
paragraph("  code")              ← YAML content leaked into the body
heading("After Embedded Fence")
```

Round-trip save output — **`title: x` is gone, the code block has leaked into the body**:

````markdown
```yaml
---
example: |
```

code

# After Embedded Fence
````

That is data loss on a plain save, with no warning.

## Root cause

`wrapFrontmatterForWebview` (`src/editor/MarkdownEditorProvider.ts`) always opens with exactly three backticks, regardless of what the frontmatter contains. CommonMark requires the closing fence to be **at least as long as** the opener, so an inner ` ``` ` run is sufficient to close a 3-backtick fence early.

## The fix

Two symmetric changes in `MarkdownEditorProvider.ts`:

1. **`wrapFrontmatterForWebview`** picks a fence **one backtick longer than the longest backtick run inside the frontmatter**. Because the opener is now longer than any inner run, CommonMark forbids the inner run from closing it, so the whole block stays intact. This mirrors `prosemirror-markdown`'s own `code_block` fence logic, so when the webview re-serializes the block it produces a fence of the same length and the round-trip is stable.
2. **`unwrapFrontmatterFromWebview`** now recognizes a fence of **3+ backticks** (`/^(`{3,})(yaml|yml|json)$/`) and matches the closing fence to the opener's length.

**Ordinary frontmatter (no backticks) is unchanged** — it still uses exactly ` ```yaml `. The only behavior that changes is the previously-corrupted case.

## Why the tests assert what they do

The corruption is introduced by the **parser**, which runs in the webview (jsdom), *between* the host-side wrap and unwrap (Node). A pure host `unwrap(wrap(x)) === x` check is textually symmetric and would **pass even with the bug**, so it cannot guard the regression. Instead the tests pin the two halves of the fix on the real provider methods:

- **Wrap** emits a fence strictly longer than any backtick run inside the frontmatter (the exact invariant that stops the parser splitting the block).
- **Unwrap** restores ` --- ` delimiters from a 4-backtick-fenced block with **no field lost**.
- A control test asserts ordinary frontmatter still uses ` ```yaml ` (no behavior change).

Both new assertions were confirmed **red before the fix, green after**.

## Verification

- `frontmatterRendering.test.ts`: 5/5 pass (2 pre-existing + 3 new).
- Full suite: **861 passed**, 0 failed (27 skipped / 121 todo pre-existing).
- `tsc --noEmit`: clean. `eslint --max-warnings 0`: clean.

## Scope

- Touches only `src/editor/MarkdownEditorProvider.ts` and its test. No webview/editor changes.
- Independent of the in-progress copy-AI-context line-number work (separate branch). Note for whoever merges that branch: its `isFrontmatterSerializedBlock` helper recognizes only an exact 3-backtick fence and should be updated to accept 3+ backticks too, to stay in sync with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)