### PR TITLE
fix(search): stabilize in-document find focus and close behavior

### DIFF
--- a/src/__tests__/webview/searchOverlay.test.ts
+++ b/src/__tests__/webview/searchOverlay.test.ts
@@ -57,6 +57,7 @@ import {
   findMatches,
   showSearchOverlay,
   hideSearchOverlay,
+  isSearchVisible,
 } from '../../webview/features/searchOverlay';
 
 type MockEditor = {
@@ -166,6 +167,13 @@ function createMockEditor(content: string) {
       },
     },
   };
+}
+
+function setWindowScrollPosition(x: number, y: number) {
+  Object.defineProperty(window, 'scrollX', { configurable: true, value: x });
+  Object.defineProperty(window, 'scrollY', { configurable: true, value: y });
+  Object.defineProperty(window, 'pageXOffset', { configurable: true, value: x });
+  Object.defineProperty(window, 'pageYOffset', { configurable: true, value: y });
 }
 
 describe('Search Overlay', () => {
@@ -319,6 +327,7 @@ describe('Search Overlay UI behaviors', () => {
     document.body.innerHTML = '';
     // Mock window.scrollTo (not implemented in jsdom)
     window.scrollTo = jest.fn();
+    setWindowScrollPosition(0, 0);
     editor = createMockEditorWithView('hello hello');
   });
 
@@ -331,6 +340,77 @@ describe('Search Overlay UI behaviors', () => {
     const input = document.querySelector('.search-overlay-input') as HTMLInputElement;
     expect(input).toBeTruthy();
     expect(document.activeElement).toBe(input);
+  });
+
+  it('keeps the search overlay open and refocuses the input when shown again', () => {
+    showSearchOverlay(editor as unknown as Editor);
+    const input = document.querySelector('.search-overlay-input') as HTMLInputElement;
+    const outsideButton = document.createElement('button');
+    document.body.appendChild(outsideButton);
+    outsideButton.focus();
+
+    expect(document.activeElement).toBe(outsideButton);
+
+    showSearchOverlay(editor as unknown as Editor);
+
+    expect(isSearchVisible()).toBe(true);
+    expect(document.activeElement).toBe(input);
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe(input.value.length);
+  });
+
+  it('preserves the existing query when refocusing an already open overlay', () => {
+    showSearchOverlay(editor as unknown as Editor);
+    const input = document.querySelector('.search-overlay-input') as HTMLInputElement;
+    input.value = 'zzz';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    input.setSelectionRange(1, 1);
+
+    showSearchOverlay(editor as unknown as Editor);
+
+    expect(isSearchVisible()).toBe(true);
+    expect(input.value).toBe('zzz');
+    expect(document.activeElement).toBe(input);
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe(input.value.length);
+  });
+
+  it('retries focus when the first focus attempt is ignored', () => {
+    jest.useFakeTimers();
+    const originalRequestAnimationFrame = window.requestAnimationFrame;
+    Object.defineProperty(window, 'requestAnimationFrame', {
+      configurable: true,
+      value: undefined,
+    });
+    const originalFocus = HTMLInputElement.prototype.focus;
+    let attempts = 0;
+    const focusSpy = jest.spyOn(HTMLInputElement.prototype, 'focus').mockImplementation(function (
+      this: HTMLInputElement,
+      options?: FocusOptions
+    ) {
+      attempts += 1;
+      if (attempts >= 3) {
+        originalFocus.call(this, options);
+      }
+    });
+
+    try {
+      showSearchOverlay(editor as unknown as Editor);
+      const input = document.querySelector('.search-overlay-input') as HTMLInputElement;
+      expect(document.activeElement).not.toBe(input);
+
+      jest.runAllTimers();
+
+      expect(document.activeElement).toBe(input);
+      expect(focusSpy).toHaveBeenCalledTimes(3);
+    } finally {
+      focusSpy.mockRestore();
+      Object.defineProperty(window, 'requestAnimationFrame', {
+        configurable: true,
+        value: originalRequestAnimationFrame,
+      });
+      jest.useRealTimers();
+    }
   });
 
   it('Cmd/Ctrl+A selects all text within the search input', () => {
@@ -366,6 +446,55 @@ describe('Search Overlay UI behaviors', () => {
     expect(secondSelection?.from).toBeGreaterThan(firstSelection.from);
     expect(document.activeElement).toBe(input);
   });
+
+  it('keeps the current match selected when closing after a search', () => {
+    editor.state.selection = { from: 0, to: 0 };
+    editor.state.doc.textBetween.mockReturnValue('');
+
+    showSearchOverlay(editor as unknown as Editor);
+    const input = document.querySelector('.search-overlay-input') as HTMLInputElement;
+    input.value = 'hello';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+
+    const matchSelection = editor.commands.setTextSelection.mock.calls.at(-1)?.[0];
+    expect(matchSelection).toEqual({ from: 1, to: 6 });
+
+    hideSearchOverlay(editor as unknown as Editor);
+
+    expect(editor.commands.setTextSelection).not.toHaveBeenLastCalledWith({ from: 0, to: 0 });
+    expect(editor.commands.setTextSelection).toHaveBeenLastCalledWith(matchSelection);
+  });
+
+  it('restores cursor position when closed without navigation or manual scrolling', () => {
+    editor.state.selection = { from: 3, to: 3 };
+    editor.state.doc.textBetween.mockReturnValue('');
+    setWindowScrollPosition(0, 120);
+
+    showSearchOverlay(editor as unknown as Editor);
+    editor.commands.setTextSelection.mockClear();
+    editor.commands.focus.mockClear();
+
+    hideSearchOverlay(editor as unknown as Editor);
+
+    expect(editor.commands.setTextSelection).toHaveBeenCalledWith({ from: 3, to: 3 });
+    expect(editor.commands.focus).toHaveBeenCalledWith();
+  });
+
+  it('does not jump back to the open position when closing after manual scrolling', () => {
+    editor.state.selection = { from: 4, to: 4 };
+    editor.state.doc.textBetween.mockReturnValue('');
+    setWindowScrollPosition(0, 100);
+
+    showSearchOverlay(editor as unknown as Editor);
+    editor.commands.setTextSelection.mockClear();
+    editor.commands.focus.mockClear();
+
+    setWindowScrollPosition(0, 900);
+    hideSearchOverlay(editor as unknown as Editor);
+
+    expect(editor.commands.setTextSelection).not.toHaveBeenCalled();
+    expect(editor.commands.focus).toHaveBeenCalledWith(undefined, { scrollIntoView: false });
+  });
 });
 
 describe('Search Overlay UI behavior (future tests)', () => {
@@ -373,6 +502,5 @@ describe('Search Overlay UI behavior (future tests)', () => {
   describe('integration tests requiring full TipTap', () => {
     it.todo('should highlight all matches with ProseMirror decorations');
     it.todo('should wrap around from last to first match');
-    it.todo('should restore cursor position when closed without navigation');
   });
 });

--- a/src/__tests__/webview/undo-sync.test.ts
+++ b/src/__tests__/webview/undo-sync.test.ts
@@ -66,7 +66,7 @@ jest.mock('./../../webview/features/imageDragDrop', () => ({
   getPendingImageCount: jest.fn(() => 0),
 }));
 jest.mock('./../../webview/features/tocOverlay', () => ({ toggleTocOverlay: jest.fn() }));
-jest.mock('./../../webview/features/searchOverlay', () => ({ toggleSearchOverlay: jest.fn() }));
+jest.mock('./../../webview/features/searchOverlay', () => ({ showSearchOverlay: jest.fn() }));
 jest.mock('./../../webview/utils/exportContent', () => ({
   collectExportContent: jest.fn(),
   getDocumentTitle: jest.fn(),
@@ -86,6 +86,13 @@ type TestingModule = {
   updateEditorContentForTests: (content: string) => void;
   isCodeContextForPasteForTests: (event: ClipboardEvent) => boolean;
   insertRawCodeTextForTests: (text: string) => void;
+  isPlainFindShortcutForTests: (event: {
+    key: string;
+    ctrlKey?: boolean;
+    metaKey?: boolean;
+    shiftKey?: boolean;
+    altKey?: boolean;
+  }) => boolean;
 };
 
 describe('webview undo/redo guards', () => {
@@ -220,5 +227,16 @@ describe('webview undo/redo guards', () => {
       type: 'text',
       text: '<table class="sq-table"><tr><td>Alice</td></tr></table>',
     });
+  });
+
+  it('handles only the plain find shortcut inside the webview', () => {
+    expect(testing.isPlainFindShortcutForTests({ key: 'f', ctrlKey: true })).toBe(true);
+    expect(testing.isPlainFindShortcutForTests({ key: 'F', metaKey: true })).toBe(true);
+    expect(testing.isPlainFindShortcutForTests({ key: 'F', ctrlKey: true, shiftKey: true })).toBe(
+      false
+    );
+    expect(testing.isPlainFindShortcutForTests({ key: 'f', ctrlKey: true, altKey: true })).toBe(
+      false
+    );
   });
 });

--- a/src/webview/editor.ts
+++ b/src/webview/editor.ts
@@ -40,7 +40,7 @@ import {
   getPendingImageCount,
 } from './features/imageDragDrop';
 import { toggleTocOverlay } from './features/tocOverlay';
-import { toggleSearchOverlay } from './features/searchOverlay';
+import { showSearchOverlay } from './features/searchOverlay';
 import { showLinkDialog } from './features/linkDialog';
 import { processPasteContent, parseFencedCode } from './utils/pasteHandler';
 import { copySelectionAsMarkdown } from './utils/copyMarkdown';
@@ -218,6 +218,12 @@ const scheduleOutlineUpdate = () => {
   }, OUTLINE_UPDATE_DEBOUNCE_MS);
 };
 
+function isPlainFindShortcut(
+  event: Pick<KeyboardEvent, 'key' | 'ctrlKey' | 'metaKey' | 'shiftKey' | 'altKey'>
+): boolean {
+  const hasPrimaryModifier = Boolean(event.metaKey) !== Boolean(event.ctrlKey);
+  return hasPrimaryModifier && !event.shiftKey && !event.altKey && event.key.toLowerCase() === 'f';
+}
 // Pending AI context reference requests, keyed by requestId. The host saves the
 // document and replies with `aiContextRefResponse`; we look up the resolver here.
 const aiContextRefCallbacks = new Map<
@@ -837,11 +843,11 @@ function initializeEditor(initialContent: string) {
       }
 
       // Intercept Cmd/Ctrl+F for in-document search
-      if (isMod && e.key === 'f') {
+      if (isPlainFindShortcut(e)) {
         e.preventDefault();
         e.stopPropagation();
         if (editor) {
-          toggleSearchOverlay(editor);
+          showSearchOverlay(editor);
         }
         return;
       }
@@ -1957,5 +1963,20 @@ export const __testing = {
   insertRawCodeTextForTests(text: string) {
     if (!editor) return;
     insertRawCodeText(editor, text);
+  },
+  isPlainFindShortcutForTests(event: {
+    key: string;
+    ctrlKey?: boolean;
+    metaKey?: boolean;
+    shiftKey?: boolean;
+    altKey?: boolean;
+  }) {
+    return isPlainFindShortcut({
+      key: event.key,
+      ctrlKey: Boolean(event.ctrlKey),
+      metaKey: Boolean(event.metaKey),
+      shiftKey: Boolean(event.shiftKey),
+      altKey: Boolean(event.altKey),
+    });
   },
 };

--- a/src/webview/features/searchOverlay.ts
+++ b/src/webview/features/searchOverlay.ts
@@ -25,12 +25,43 @@ const searchPluginKey = new PluginKey('search-highlight');
 let searchOverlayElement: HTMLElement | null = null;
 let isVisible = false;
 let savedSelection: { from: number; to: number } | null = null;
+let savedScrollPosition: { x: number; y: number } | null = null;
 let currentQuery = '';
 let currentMatches: Array<{ from: number; to: number }> = [];
 let currentMatchIndex = -1;
 let searchPlugin: Plugin | null = null;
+let focusRequestId = 0;
+const SCROLL_CHANGE_EPSILON = 1;
 const isOverlayInDom = () =>
   Boolean(searchOverlayElement && document.body.contains(searchOverlayElement));
+
+function getWindowScrollPosition(): { x: number; y: number } {
+  return {
+    x: typeof window.scrollX === 'number' ? window.scrollX : window.pageXOffset || 0,
+    y: typeof window.scrollY === 'number' ? window.scrollY : window.pageYOffset || 0,
+  };
+}
+
+function hasScrolledSinceSearchOpened(): boolean {
+  if (!savedScrollPosition) {
+    return false;
+  }
+
+  const currentScrollPosition = getWindowScrollPosition();
+  return (
+    Math.abs(currentScrollPosition.x - savedScrollPosition.x) > SCROLL_CHANGE_EPSILON ||
+    Math.abs(currentScrollPosition.y - savedScrollPosition.y) > SCROLL_CHANGE_EPSILON
+  );
+}
+
+function focusEditor(editor: Editor, preventScroll: boolean) {
+  if (preventScroll) {
+    editor.commands.focus(undefined, { scrollIntoView: false });
+    return;
+  }
+
+  editor.commands.focus();
+}
 
 /**
  * Create the search plugin for decorations
@@ -409,15 +440,52 @@ export function createSearchOverlay(editor: Editor): HTMLElement {
 }
 
 function focusSearchInput(selectText = true) {
-  const searchInput = searchOverlayElement?.querySelector(
-    '.search-overlay-input'
-  ) as HTMLInputElement | null;
-  if (!searchInput) return;
+  const requestId = ++focusRequestId;
+  let attempts = 0;
+  let initialValue: string | null = null;
+  const maxAttempts = 6;
 
-  searchInput.focus();
-  if (selectText) {
-    searchInput.select();
-  }
+  const scheduleNextAttempt = () => {
+    if (typeof window.requestAnimationFrame === 'function') {
+      window.requestAnimationFrame(applyFocus);
+    } else {
+      window.setTimeout(applyFocus, 16);
+    }
+  };
+
+  const applyFocus = () => {
+    if (!isVisible || !isOverlayInDom()) return;
+    if (requestId !== focusRequestId) return;
+
+    const searchInput = searchOverlayElement?.querySelector(
+      '.search-overlay-input'
+    ) as HTMLInputElement | null;
+    if (!searchInput) return;
+    if (initialValue === null) {
+      initialValue = searchInput.value;
+    }
+
+    if (document.activeElement !== searchInput) {
+      searchInput.focus({ preventScroll: true });
+    }
+    if (
+      selectText &&
+      searchInput.value === initialValue &&
+      document.activeElement === searchInput
+    ) {
+      searchInput.select();
+    }
+
+    attempts += 1;
+    if (document.activeElement !== searchInput && attempts < maxAttempts) {
+      scheduleNextAttempt();
+    }
+  };
+
+  applyFocus();
+  // TipTap and Chromium can both settle focus after the keyboard event that opens find.
+  // Verify on the next frame even when immediate focus initially succeeds.
+  scheduleNextAttempt();
 }
 
 /**
@@ -426,6 +494,7 @@ function focusSearchInput(selectText = true) {
 export function showSearchOverlay(editor: Editor): void {
   // Ensure search plugin is registered
   ensureSearchPlugin(editor);
+  const wasVisible = isVisible && isOverlayInDom();
 
   if (!isOverlayInDom()) {
     searchOverlayElement = null;
@@ -437,6 +506,7 @@ export function showSearchOverlay(editor: Editor): void {
   // Save current selection
   const { from, to } = editor.state.selection;
   savedSelection = { from, to };
+  savedScrollPosition = getWindowScrollPosition();
 
   // Get selected text as initial query
   const selectedText = editor.state.doc.textBetween(from, to, ' ');
@@ -444,6 +514,11 @@ export function showSearchOverlay(editor: Editor): void {
   // Show overlay
   searchOverlayElement.classList.add('visible');
   isVisible = true;
+
+  if (wasVisible) {
+    focusSearchInput();
+    return;
+  }
 
   // Focus input and set selected text
   const searchInput = searchOverlayElement.querySelector(
@@ -465,6 +540,9 @@ export function showSearchOverlay(editor: Editor): void {
  */
 export function hideSearchOverlay(editor: Editor, restorePosition = true): void {
   if (!searchOverlayElement) return;
+
+  const hadActiveMatch = currentMatches.length > 0 && currentMatchIndex >= 0;
+  const shouldPreventFocusScroll = restorePosition && hasScrolledSinceSearchOpened();
 
   searchOverlayElement.classList.remove('visible');
   isVisible = false;
@@ -495,8 +573,10 @@ export function hideSearchOverlay(editor: Editor, restorePosition = true): void 
     searchInput.classList.remove('no-results');
   }
 
-  // Restore previous position if requested
-  if (restorePosition && savedSelection) {
+  // Restore previous position only when search did not navigate to a match.
+  // When a match is active, leaving the match selected avoids snapping scroll
+  // back to the stale cursor location from before find opened.
+  if (restorePosition && !hadActiveMatch && !shouldPreventFocusScroll && savedSelection) {
     try {
       editor.commands.setTextSelection(savedSelection);
     } catch {
@@ -504,8 +584,9 @@ export function hideSearchOverlay(editor: Editor, restorePosition = true): void 
     }
   }
 
-  // Focus editor
-  editor.commands.focus();
+  focusEditor(editor, shouldPreventFocusScroll);
+  savedSelection = null;
+  savedScrollPosition = null;
 }
 
 /**


### PR DESCRIPTION
## Description

Stabilizes the floating in-document find overlay inside the custom editor webview. Ctrl/Cmd+F now opens find with the input focused and selected, VS Code workspace-search shortcuts with extra modifiers are allowed to keep working, and closing find no longer moves the user away from the current match or manually scrolled viewport.

This PR is intentionally scoped to search overlay behavior only. It does not include any of the larger forked editor/export integrations.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test addition/modification

## Related Issues

No linked issue. This was found while testing the custom editor find overlay behavior.

## Changes Made

- Focus and select the floating find input when opened from Ctrl/Cmd+F.
- Preserve VS Code workspace search shortcuts that include Shift or Alt modifiers.
- Retry input focus across frames when TipTap or Chromium reclaims focus after the opening key event.
- Keep the current search match selected when closing after navigating to a match.
- Track the scroll position when find opens and avoid restoring/focusing the old selection if the user manually scrolled before closing find.
- Add regression coverage for shortcut routing, input focus, active-match close behavior, cursor restoration, and manual-scroll close behavior.

## Screen Recording / Visual Demo

- [ ] I have included a screen recording showing the before state
- [ ] I have included a screen recording showing the after state

Screen recording not included in this initial PR. The behavior is covered by focused regression tests; I can add a short recording if maintainers want it before review.

## Testing

- [x] Targeted tests pass: `npm test -- --runInBand src/__tests__/webview/searchOverlay.test.ts src/__tests__/webview/undo-sync.test.ts --silent`
- [x] Linting passes: `npm run lint`
- [x] Build succeeds: `npm run build:debug`

### Test Environment

- OS: Linux
- Node Version: project npm environment

## Documentation

- [x] No README/docs changes needed; this is a behavioral fix to an existing feature.

## Checklist

- [x] My code follows the project coding standards.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings or errors.
- [x] I have added tests that prove the fix is effective.
- [x] New and existing targeted tests pass locally.

## Additional Notes

This is split out as a small standalone PR so it can be reviewed independently from larger fork integration work.