### PR TITLE
fix(tests): clear webview timers after Jest runs

### DIFF
--- a/src/__tests__/webview/auditOverlay.test.ts
+++ b/src/__tests__/webview/auditOverlay.test.ts
@@ -7,7 +7,12 @@ import StarterKit from '@tiptap/starter-kit';
 import { Markdown } from '@tiptap/markdown';
 import Link from '@tiptap/extension-link';
 import { CustomImage } from '../../webview/extensions/customImage';
-import { showAuditOverlay, showToast, dismissToast } from '../../webview/features/auditOverlay';
+import {
+  showAuditOverlay,
+  showToast,
+  dismissToast,
+  clearToasts,
+} from '../../webview/features/auditOverlay';
 import { AuditIssue } from '../../webview/features/auditDocument';
 
 let mockVscodeApi: { postMessage: jest.Mock };
@@ -45,10 +50,7 @@ describe('Audit Overlay UI', () => {
     if (overlay) {
       overlay.remove();
     }
-    const toastContainer = document.getElementById('toast-container');
-    if (toastContainer) {
-      toastContainer.remove();
-    }
+    clearToasts();
     delete (window as any).vscode;
     delete (window as any).resolveImagePath;
     jest.clearAllMocks();
@@ -516,10 +518,8 @@ describe('Audit Overlay UI', () => {
 
 describe('Toast Notifications', () => {
   afterEach(() => {
-    const toastContainer = document.getElementById('toast-container');
-    if (toastContainer) {
-      toastContainer.remove();
-    }
+    clearToasts();
+    jest.useRealTimers();
   });
 
   it('shows a success toast with correct styling', () => {
@@ -600,5 +600,16 @@ describe('Toast Notifications', () => {
       expect(stillHere).not.toBeNull();
       done();
     }, 3500);
+  });
+
+  it('clears pending toast animation and dismissal timers', () => {
+    jest.useFakeTimers();
+
+    showToast('Success message', 'success');
+    expect(jest.getTimerCount()).toBeGreaterThan(0);
+
+    clearToasts();
+
+    expect(jest.getTimerCount()).toBe(0);
   });
 });

--- a/src/__tests__/webview/imageHover.test.ts
+++ b/src/__tests__/webview/imageHover.test.ts
@@ -12,6 +12,7 @@ import { JSDOM } from 'jsdom';
 import {
   showImageMetadataFooter,
   hideImageMetadataFooter,
+  clearPendingImageMetadataRequests,
 } from '../../webview/features/imageMetadata';
 
 // Mock vscode API
@@ -57,7 +58,10 @@ describe('Image Hover Overlay Toggle', () => {
   });
 
   afterEach(() => {
+    clearPendingImageMetadataRequests();
     document.body.innerHTML = '';
+    delete (window as any)._metadataCallbacks;
+    jest.useRealTimers();
     jest.clearAllMocks();
   });
 
@@ -90,6 +94,19 @@ describe('Image Hover Overlay Toggle', () => {
       const footer = wrapper.querySelector('.image-metadata-footer') as HTMLElement;
       expect(footer).toBeTruthy();
       expect(footer.style.display).toBe('none');
+    });
+
+    it('clears pending metadata request timers', () => {
+      jest.useFakeTimers();
+      (window as any).showImageHoverOverlay = true;
+
+      showImageMetadataFooter(img, wrapper, mockVscodeApi);
+
+      expect(jest.getTimerCount()).toBeGreaterThan(0);
+
+      clearPendingImageMetadataRequests();
+
+      expect(jest.getTimerCount()).toBe(0);
     });
   });
 

--- a/src/webview/features/auditOverlay.ts
+++ b/src/webview/features/auditOverlay.ts
@@ -22,6 +22,100 @@ const MAX_SUGGESTION_PILLS = 5;
 
 // Toast auto-dismiss timeout in milliseconds
 const TOAST_AUTO_DISMISS_MS = 3000;
+const TOAST_REMOVAL_ANIMATION_MS = 200;
+
+type ToastTimerHandle = ReturnType<typeof setTimeout>;
+type ToastFrameHandle = ReturnType<typeof requestAnimationFrame>;
+
+type ToastLifecycle = {
+  showFrame?: ToastFrameHandle;
+  autoDismiss?: ToastTimerHandle;
+  removal?: ToastTimerHandle;
+};
+
+const toastLifecycles = new Map<string, ToastLifecycle>();
+
+function getToastLifecycle(toastId: string): ToastLifecycle {
+  let lifecycle = toastLifecycles.get(toastId);
+  if (!lifecycle) {
+    lifecycle = {};
+    toastLifecycles.set(toastId, lifecycle);
+  }
+  return lifecycle;
+}
+
+function maybeUnrefTimer(timer: ToastTimerHandle): void {
+  const maybeNodeTimer = timer as unknown as { unref?: () => void };
+  if (typeof maybeNodeTimer.unref === 'function') {
+    maybeNodeTimer.unref();
+  }
+}
+
+function clearToastTimer(timer: ToastTimerHandle | undefined): void {
+  if (typeof timer !== 'undefined') {
+    clearTimeout(timer);
+  }
+}
+
+function clearToastLifecycle(toastId: string): void {
+  const lifecycle = toastLifecycles.get(toastId);
+  if (!lifecycle) return;
+
+  if (typeof lifecycle.showFrame !== 'undefined' && typeof cancelAnimationFrame === 'function') {
+    cancelAnimationFrame(lifecycle.showFrame);
+  }
+  clearToastTimer(lifecycle.autoDismiss);
+  clearToastTimer(lifecycle.removal);
+  toastLifecycles.delete(toastId);
+}
+
+function scheduleToastFrame(toastId: string, callback: () => void): void {
+  if (typeof requestAnimationFrame !== 'function') {
+    callback();
+    return;
+  }
+
+  const lifecycle = getToastLifecycle(toastId);
+  lifecycle.showFrame = requestAnimationFrame(() => {
+    const activeLifecycle = toastLifecycles.get(toastId);
+    if (activeLifecycle) {
+      delete activeLifecycle.showFrame;
+    }
+    callback();
+  });
+}
+
+function scheduleToastTimer(
+  toastId: string,
+  key: 'autoDismiss' | 'removal',
+  callback: () => void,
+  delayMs: number
+): void {
+  const lifecycle = getToastLifecycle(toastId);
+  clearToastTimer(lifecycle[key]);
+
+  const timer = setTimeout(() => {
+    const activeLifecycle = toastLifecycles.get(toastId);
+    if (activeLifecycle) {
+      delete activeLifecycle[key];
+    }
+    callback();
+  }, delayMs);
+  maybeUnrefTimer(timer);
+  lifecycle[key] = timer;
+}
+
+function scheduleToastRemoval(toastId: string, toast: HTMLElement): void {
+  scheduleToastTimer(
+    toastId,
+    'removal',
+    () => {
+      toast.remove();
+      clearToastLifecycle(toastId);
+    },
+    TOAST_REMOVAL_ANIMATION_MS
+  );
+}
 
 /**
  * Display a toast notification.
@@ -62,18 +156,21 @@ export function showToast(message: string, type: 'success' | 'info' | 'loading' 
   toastContainer.appendChild(toast);
 
   // Trigger animation
-  requestAnimationFrame(() => {
+  scheduleToastFrame(toastId, () => {
     toast.classList.add('visible');
   });
 
   // Auto-dismiss only for non-loading toasts
   if (type !== 'loading') {
-    setTimeout(() => {
-      toast.classList.remove('visible');
-      setTimeout(() => {
-        toast.remove();
-      }, 200); // Wait for fade-out animation
-    }, TOAST_AUTO_DISMISS_MS);
+    scheduleToastTimer(
+      toastId,
+      'autoDismiss',
+      () => {
+        toast.classList.remove('visible');
+        scheduleToastRemoval(toastId, toast);
+      },
+      TOAST_AUTO_DISMISS_MS
+    );
   }
 
   return toastId;
@@ -87,11 +184,30 @@ export function showToast(message: string, type: 'success' | 'info' | 'loading' 
 export function dismissToast(toastId: string): void {
   const toast = document.getElementById(toastId);
   if (toast) {
+    const lifecycle = getToastLifecycle(toastId);
+    clearToastTimer(lifecycle.autoDismiss);
+    delete lifecycle.autoDismiss;
+
     toast.classList.remove('visible');
-    setTimeout(() => {
-      toast.remove();
-    }, 200); // Wait for fade-out animation
+    scheduleToastRemoval(toastId, toast);
+  } else {
+    clearToastLifecycle(toastId);
   }
+}
+
+/**
+ * Remove all active toasts and clear any scheduled toast timers.
+ * Useful when the webview or tests reset the DOM before auto-dismiss timers fire.
+ */
+export function clearToasts(): void {
+  for (const toastId of Array.from(toastLifecycles.keys())) {
+    clearToastLifecycle(toastId);
+  }
+
+  document.querySelectorAll('.toast').forEach(toast => {
+    toast.remove();
+  });
+  document.getElementById('toast-container')?.remove();
 }
 
 /**

--- a/src/webview/features/imageMetadata.ts
+++ b/src/webview/features/imageMetadata.ts
@@ -27,6 +27,23 @@ export interface ImageMetadata {
 
 // Cache metadata per image to avoid refetching on every hover
 const metadataCache = new Map<string, ImageMetadata>();
+const pendingMetadataTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
+
+type MetadataCallback = (metadata: ImageMetadata | null) => void;
+
+function getMetadataCallbacks(): Map<string, MetadataCallback> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const windowWithCallbacks = window as any;
+  windowWithCallbacks._metadataCallbacks = windowWithCallbacks._metadataCallbacks || new Map();
+  return windowWithCallbacks._metadataCallbacks;
+}
+
+function maybeUnrefTimer(timer: ReturnType<typeof setTimeout>): void {
+  const maybeNodeTimer = timer as unknown as { unref?: () => void };
+  if (typeof maybeNodeTimer.unref === 'function') {
+    maybeNodeTimer.unref();
+  }
+}
 
 /**
  * Get cached metadata for an image path
@@ -47,6 +64,20 @@ export function clearImageMetadataCache(imagePath?: string): void {
   } else {
     metadataCache.clear();
   }
+}
+
+/**
+ * Clear unresolved metadata requests and their timeout handles.
+ * This is used when the webview/test DOM is reset before the extension host responds.
+ */
+export function clearPendingImageMetadataRequests(): void {
+  for (const timeout of pendingMetadataTimeouts.values()) {
+    clearTimeout(timeout);
+  }
+  pendingMetadataTimeouts.clear();
+
+  const callbacks = getMetadataCallbacks();
+  callbacks.clear();
 }
 
 /**
@@ -159,10 +190,15 @@ export function getImageMetadata(
     const requestId = `metadata-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
 
     // Store callback
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (window as any)._metadataCallbacks = (window as any)._metadataCallbacks || new Map();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (window as any)._metadataCallbacks.set(requestId, (metadata: ImageMetadata | null) => {
+    const callbacks = getMetadataCallbacks();
+    callbacks.set(requestId, (metadata: ImageMetadata | null) => {
+      callbacks.delete(requestId);
+      const timeout = pendingMetadataTimeouts.get(requestId);
+      if (timeout) {
+        clearTimeout(timeout);
+        pendingMetadataTimeouts.delete(requestId);
+      }
+
       if (metadata) {
         // Preserve existing dimensions if they were set (e.g., from resize)
         // This ensures correct dimensions are shown even if image hasn't fully loaded yet
@@ -186,14 +222,15 @@ export function getImageMetadata(
     });
 
     // Timeout after 5 seconds
-    setTimeout(() => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const callbacks = (window as any)._metadataCallbacks;
+    const timeout = setTimeout(() => {
+      pendingMetadataTimeouts.delete(requestId);
       if (callbacks && callbacks.has(requestId)) {
         callbacks.delete(requestId);
         resolve(null);
       }
     }, 5000);
+    maybeUnrefTimer(timeout);
+    pendingMetadataTimeouts.set(requestId, timeout);
   });
 }
 


### PR DESCRIPTION
## Description

Makes webview timer cleanup deterministic in Jest so tests do not leave toast or image metadata timeouts alive after DOM teardown. The runtime features keep their existing behavior, but tests now have cleanup hooks that clear scheduled animation, dismissal, removal, metadata-response, and callback state.

This PR is intentionally limited to test/runtime cleanup for existing webview features.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test addition/modification

## Related Issues

No linked issue. This addresses Jest open-handle noise observed while running the webview test suite.

## Changes Made

- Track toast animation, auto-dismiss, and removal timers so they can be cleared deterministically.
- Add a toast cleanup helper used by audit overlay tests.
- Track pending image metadata response timeouts and callback entries.
- Clear image metadata callbacks when requests resolve, time out, or tests reset the DOM.
- Add regression coverage proving toast and metadata cleanup leaves no pending fake timers.
- Update affected tests to call cleanup helpers in `afterEach`.

## Screen Recording / Visual Demo

Not applicable; this is test infrastructure/runtime cleanup with no visible UI change.

## Testing

- [x] Targeted tests pass: `npm test -- --runInBand src/__tests__/webview/auditOverlay.test.ts src/__tests__/webview/imageHover.test.ts --silent`
- [x] Linting passes: `npm run lint`
- [x] Build succeeds: `npm run build:debug`

### Test Environment

- OS: Linux
- Node Version: project npm environment

## Documentation

- [x] No README/docs changes needed; this only adds cleanup hooks and tests.

## Checklist

- [x] My code follows the project coding standards.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings or errors.
- [x] I have added tests that prove the fix is effective.
- [x] New and existing targeted tests pass locally.

## Additional Notes

This should make repeated Jest runs quieter and more reliable without changing user-facing toast or image metadata behavior.