### PR TITLE
Add opt-in autosave setting (markdownForHumans.autoSave.enabled)

### DIFF
--- a/package.json
+++ b/package.json
@@ -249,6 +249,12 @@
           "default": "vscode",
           "description": "Controls the editor's color theme. 'Follow VS Code theme' mirrors your active VS Code theme. 'Always light'/'Always dark' keep the editor light or dark regardless of VS Code: when VS Code's theme already matches that appearance the editor uses your real theme, otherwise it falls back to a built-in light/dark theme. The toolbar toggle switches between light and dark and applies to all open editors.",
           "scope": "application"
+        },
+        "markdownForHumans.autoSave.enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Automatically save the file a short delay after you stop typing in this editor, independent of VS Code's own files.autoSave setting. Off by default: with this disabled, the editor's original behavior applies (an explicit Cmd/Ctrl+S, or VS Code's own files.autoSave if you have that configured).",
+          "scope": "application"
         }
       }
     }

--- a/src/__tests__/editor/autoSave.test.ts
+++ b/src/__tests__/editor/autoSave.test.ts
@@ -1,0 +1,216 @@
+import * as vscode from 'vscode';
+import { Position } from 'vscode';
+import { MarkdownEditorProvider } from '../../editor/MarkdownEditorProvider';
+
+// Helper to create a minimal mock TextDocument backing an `applyEdit` call.
+function createDocument(content: string, uri = 'file://test.md') {
+  return {
+    getText: jest.fn(() => content),
+    uri: { toString: () => uri, scheme: 'file' },
+    positionAt: jest.fn((offset: number) => new Position(0, offset)),
+    isDirty: false,
+    save: jest.fn(async () => true),
+  };
+}
+
+function mockConfig(overrides: Record<string, unknown>) {
+  return {
+    get: jest.fn((key: string, defaultValue?: unknown) =>
+      key in overrides ? overrides[key] : defaultValue
+    ),
+    update: jest.fn(),
+  } as unknown as vscode.WorkspaceConfiguration;
+}
+
+type ProviderInternals = {
+  handleWebviewMessage: (
+    message: { type: string; [key: string]: unknown },
+    document: vscode.TextDocument,
+    webview: { postMessage: jest.Mock }
+  ) => void;
+  autoSaveTimers: Map<string, unknown>;
+};
+
+describe('markdownForHumans.autoSave.enabled', () => {
+  let getConfigurationSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    getConfigurationSpy?.mockRestore();
+  });
+
+  it('does not save automatically when the setting is off (default)', async () => {
+    getConfigurationSpy = jest
+      .spyOn(vscode.workspace, 'getConfiguration')
+      .mockReturnValue(mockConfig({ 'markdownForHumans.autoSave.enabled': false }));
+
+    const provider = new MarkdownEditorProvider({} as unknown as vscode.ExtensionContext);
+    const document = createDocument('hello world');
+    document.isDirty = true;
+    const webview = { postMessage: jest.fn() };
+
+    workspaceApplyEdit().mockResolvedValue(true);
+
+    (provider as unknown as ProviderInternals).handleWebviewMessage(
+      { type: 'edit', content: 'hi world', editReason: 'typing' },
+      document as unknown as vscode.TextDocument,
+      webview
+    );
+
+    await flushMicrotasks();
+    jest.advanceTimersByTime(5000);
+    await flushMicrotasks();
+
+    expect(document.save).not.toHaveBeenCalled();
+  });
+
+  it('saves a short delay after typing stops once enabled', async () => {
+    getConfigurationSpy = jest
+      .spyOn(vscode.workspace, 'getConfiguration')
+      .mockReturnValue(mockConfig({ 'markdownForHumans.autoSave.enabled': true }));
+
+    const provider = new MarkdownEditorProvider({} as unknown as vscode.ExtensionContext);
+    const document = createDocument('hello world');
+    document.isDirty = true;
+    const webview = { postMessage: jest.fn() };
+
+    workspaceApplyEdit().mockResolvedValue(true);
+
+    (provider as unknown as ProviderInternals).handleWebviewMessage(
+      { type: 'edit', content: 'hi world', editReason: 'typing' },
+      document as unknown as vscode.TextDocument,
+      webview
+    );
+
+    await flushMicrotasks();
+    expect(document.save).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1000);
+    await flushMicrotasks();
+
+    expect(document.save).toHaveBeenCalledTimes(1);
+  });
+
+  it('debounces repeated edits into a single save', async () => {
+    getConfigurationSpy = jest
+      .spyOn(vscode.workspace, 'getConfiguration')
+      .mockReturnValue(mockConfig({ 'markdownForHumans.autoSave.enabled': true }));
+
+    const provider = new MarkdownEditorProvider({} as unknown as vscode.ExtensionContext);
+    const document = createDocument('hello world');
+    document.isDirty = true;
+    const webview = { postMessage: jest.fn() };
+
+    workspaceApplyEdit().mockResolvedValue(true);
+
+    (provider as unknown as ProviderInternals).handleWebviewMessage(
+      { type: 'edit', content: 'hi world', editReason: 'typing' },
+      document as unknown as vscode.TextDocument,
+      webview
+    );
+    await flushMicrotasks();
+    jest.advanceTimersByTime(500);
+
+    (provider as unknown as ProviderInternals).handleWebviewMessage(
+      { type: 'edit', content: 'hi world again', editReason: 'typing' },
+      document as unknown as vscode.TextDocument,
+      webview
+    );
+    await flushMicrotasks();
+    jest.advanceTimersByTime(500);
+    expect(document.save).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(500);
+    await flushMicrotasks();
+
+    expect(document.save).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not save when the document is already clean', async () => {
+    getConfigurationSpy = jest
+      .spyOn(vscode.workspace, 'getConfiguration')
+      .mockReturnValue(mockConfig({ 'markdownForHumans.autoSave.enabled': true }));
+
+    const provider = new MarkdownEditorProvider({} as unknown as vscode.ExtensionContext);
+    const document = createDocument('hi world');
+    document.isDirty = false;
+    const webview = { postMessage: jest.fn() };
+
+    workspaceApplyEdit().mockResolvedValue(true);
+
+    (provider as unknown as ProviderInternals).handleWebviewMessage(
+      { type: 'edit', content: 'hi world', editReason: 'typing' },
+      document as unknown as vscode.TextDocument,
+      webview
+    );
+    await flushMicrotasks();
+    jest.advanceTimersByTime(1000);
+    await flushMicrotasks();
+
+    expect(document.save).not.toHaveBeenCalled();
+  });
+
+  it('skips untitled documents even when enabled', async () => {
+    getConfigurationSpy = jest
+      .spyOn(vscode.workspace, 'getConfiguration')
+      .mockReturnValue(mockConfig({ 'markdownForHumans.autoSave.enabled': true }));
+
+    const provider = new MarkdownEditorProvider({} as unknown as vscode.ExtensionContext);
+    const document = createDocument('hello world', 'untitled:Untitled-1');
+    document.uri.scheme = 'untitled';
+    document.isDirty = true;
+    const webview = { postMessage: jest.fn() };
+
+    workspaceApplyEdit().mockResolvedValue(true);
+
+    (provider as unknown as ProviderInternals).handleWebviewMessage(
+      { type: 'edit', content: 'hi world', editReason: 'typing' },
+      document as unknown as vscode.TextDocument,
+      webview
+    );
+    await flushMicrotasks();
+    jest.advanceTimersByTime(5000);
+    await flushMicrotasks();
+
+    expect(document.save).not.toHaveBeenCalled();
+  });
+
+  it('does not schedule a save for save-policy-enforce edits', async () => {
+    getConfigurationSpy = jest
+      .spyOn(vscode.workspace, 'getConfiguration')
+      .mockReturnValue(mockConfig({ 'markdownForHumans.autoSave.enabled': true }));
+
+    const provider = new MarkdownEditorProvider({} as unknown as vscode.ExtensionContext);
+    const document = createDocument('hello world');
+    document.isDirty = true;
+    const webview = { postMessage: jest.fn() };
+
+    workspaceApplyEdit().mockResolvedValue(true);
+
+    (provider as unknown as ProviderInternals).handleWebviewMessage(
+      { type: 'edit', content: 'hi world', editReason: 'save-policy-enforce' },
+      document as unknown as vscode.TextDocument,
+      webview
+    );
+    await flushMicrotasks();
+    jest.advanceTimersByTime(5000);
+    await flushMicrotasks();
+
+    expect(document.save).not.toHaveBeenCalled();
+  });
+});
+
+function workspaceApplyEdit() {
+  return vscode.workspace.applyEdit as jest.Mock;
+}
+
+async function flushMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}

--- a/src/editor/MarkdownEditorProvider.ts
+++ b/src/editor/MarkdownEditorProvider.ts
@@ -255,6 +255,13 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
   // first time a custom editor opens so tests that never call `resolveCustomTextEditor`
   // don't need this VS Code API on their mock.
   private windowStateListener: vscode.Disposable | undefined;
+  // Debounce timers for `markdownForHumans.autoSave.enabled`, keyed by document
+  // URI. This setting is independent of VS Code's own `files.autoSave` — it's
+  // MFH saving on the user's behalf a short delay after typing stops, separate
+  // from the `flushAndSaveIfDirty` bridge (which only fires on focus/window
+  // changes and depends on `files.autoSave` being set to onFocusChange/onWindowChange).
+  private autoSaveTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private static readonly AUTO_SAVE_DEBOUNCE_MS = 1000;
   // --- Audit Search Tuning ---
   /**
    * Minimum length required to attempt ANY file suggestions.
@@ -633,6 +640,11 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
       this.pendingEdits.delete(docUri);
       this.lastWebviewContent.delete(docUri);
       this.inFlightApplyEdits.delete(docUri);
+      const autoSaveTimer = this.autoSaveTimers.get(docUri);
+      if (autoSaveTimer) {
+        clearTimeout(autoSaveTimer);
+        this.autoSaveTimers.delete(docUri);
+      }
       if (this.openPanels.get(docUri)?.panel === webviewPanel) {
         this.openPanels.delete(docUri);
       }
@@ -730,14 +742,23 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
         // explicit `save` message (Ctrl+S), when `copyAiContextRef` saves after
         // user confirmation, or when the autosave bridge fires `document.save()`.
         const docUri = document.uri.toString();
+        const editReason =
+          (message.editReason as 'typing' | 'save-policy-enforce' | undefined) ?? 'typing';
         const editPromise = this.applyEdit(message.content as string, document, {
-          editReason:
-            (message.editReason as 'typing' | 'save-policy-enforce' | undefined) ?? 'typing',
+          editReason,
         });
         // Track the latest in-flight edit so `flushAndSaveIfDirty` can await
         // it before persisting; otherwise an in-flight WorkspaceEdit could
         // land after save() and the saved bytes would be stale.
         this.inFlightApplyEdits.set(docUri, editPromise);
+        // `markdownForHumans.autoSave.enabled` debounced save — only for
+        // ordinary typing edits. Save-policy-enforce edits are already saved
+        // (or prompted for) by `handleBlankLineModeSavePolicy`.
+        if (editReason === 'typing') {
+          void editPromise.then(success => {
+            if (success) this.scheduleAutoSave(document);
+          });
+        }
         void editPromise.finally(() => {
           if (this.inFlightApplyEdits.get(docUri) === editPromise) {
             this.inFlightApplyEdits.delete(docUri);
@@ -3403,6 +3424,37 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
     } catch (error) {
       console.error('[MD4H] Autosave document.save() failed:', error);
     }
+  }
+
+  /**
+   * Debounced save for `markdownForHumans.autoSave.enabled`. Unlike
+   * `flushAndSaveIfDirty` (which bridges VS Code's own `files.autoSave` focus
+   * events), this setting is MFH-specific: it saves a short delay after the
+   * user stops typing, regardless of focus and regardless of `files.autoSave`.
+   * Off by default, so the original explicit-save behavior is unchanged unless
+   * a user opts in.
+   *
+   * No-ops for untitled documents — saving those would pop a "Save As" dialog.
+   */
+  private scheduleAutoSave(document: vscode.TextDocument): void {
+    if (document.uri.scheme === 'untitled') return;
+
+    const config = vscode.workspace.getConfiguration();
+    const enabled = config.get<boolean>('markdownForHumans.autoSave.enabled', false);
+    if (!enabled) return;
+
+    const docUri = document.uri.toString();
+    const existing = this.autoSaveTimers.get(docUri);
+    if (existing) clearTimeout(existing);
+
+    const timer = setTimeout(() => {
+      this.autoSaveTimers.delete(docUri);
+      if (!document.isDirty) return;
+      void document.save().then(undefined, (error: unknown) => {
+        console.error('[MD4H] Auto-save document.save() failed:', error);
+      });
+    }, MarkdownEditorProvider.AUTO_SAVE_DEBOUNCE_MS);
+    this.autoSaveTimers.set(docUri, timer);
   }
 
   /**


### PR DESCRIPTION
## Summary
- Add `markdownForHumans.autoSave.enabled` (default `false`) — an MFH-specific autosave that saves the document ~1s after typing stops, independent of VS Code's own `files.autoSave` setting. Off by default, so existing explicit-save behavior is unchanged unless a user opts in.

The settings default to preserving current behavior; it's purely opt-in.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `autoSave.test.ts`
- [x] Built, packaged, and manually installed locally; verified both settings and their behavior in the running extension