### PR TITLE
feat: add zoom and pan viewer for mermaid diagrams

### DIFF
--- a/docs/QA_MANUAL.md
+++ b/docs/QA_MANUAL.md
@@ -218,15 +218,20 @@ Pick one:
     ```
 - Single click highlights the block and shows “Double-click to edit”.
 - Double click opens a modal editor (textarea), `Cmd/Ctrl+S` saves inside the modal.
+- Hovering a rendered diagram reveals a magnifier button in its top-right corner, which opens the diagram in a full-pane viewer.
 
 **What to do**
 - Insert a template and verify rendering.
 - Edit to an invalid diagram and confirm an error UI appears (and source remains accessible).
+- Open the viewer, then zoom with the wheel, the `+`/`-` buttons, and the `+`/`-` keys; pan by dragging; press `0` or the fit button to re-fit; close with `Esc`, the close button, or a click on empty space.
+- Zoom well past 100% and check the diagram stays sharp (it is re-rendered vector, not an upscaled bitmap).
+- Tab through the viewer controls and confirm focus stays inside it and returns to the magnifier on close.
 
 **Expected**
 - Valid Mermaid renders as SVG.
-- Invalid Mermaid shows a clear error without breaking the editor.
-- Markdown round-trips as a fenced ` ```mermaid ` block.
+- Invalid Mermaid shows a clear error without breaking the editor, and the magnifier button is hidden.
+- Markdown round-trips as a fenced ` ```mermaid ` block; zooming and panning never modify the document.
+- The viewer opens fitted to the pane, and dragging the diagram does not dismiss it.
 
 ### 5.11 Images (insert, drag/drop, menu actions, resize, rename)
 

--- a/roadmap/shipped/task-mermaid-lightbox.md
+++ b/roadmap/shipped/task-mermaid-lightbox.md
@@ -1,0 +1,163 @@
+# Task: Mermaid diagram lightbox (zoom & pan)
+
+## 1. Task Metadata
+
+- **Task name:** Mermaid diagram lightbox (zoom & pan)
+- **Slug:** mermaid-lightbox
+- **Status:** shipped
+- **Created:** 2026-08-15
+- **Last updated:** 2026-08-15
+- **Shipped:** 2026-08-15
+
+---
+
+## 2. Context & Problem
+
+**Current state:**
+- Rendered Mermaid diagrams are sized to the editor column (`.mermaid-render svg { max-width: 100% }`) with no way to inspect them closer.
+- Single click highlights the node; double click opens the code editor. Neither reveals detail.
+
+**Pain points:**
+- **Dense diagrams are unreadable:** a wide flowchart or sequence diagram shrinks to fit the column, and node labels become too small to read.
+- **No way to inspect a region:** users cannot magnify one part of a large diagram while keeping their place in the document.
+- **Editing to read is wrong:** the only current escape is opening the code modal and reading the source, which is not the same as reading the picture.
+
+**Why it matters:**
+- Diagrams are a primary reason to use Mermaid in a WYSIWYG editor; if they can't be read, the feature is decorative.
+- Every diagramming tool (draw.io, Excalidraw, GitHub's own Mermaid renderer) offers zoom and pan. Its absence reads as missing, not minimal.
+
+---
+
+## 3. Desired Outcome & Scope
+
+**Success criteria:**
+- A rendered diagram can be opened in a viewer that fills the editor pane, fitted and centred on open.
+- Zoom works via wheel, on-screen buttons, and keyboard; pan works by dragging.
+- The diagram stays sharp at high zoom (vector re-render, not an upscaled bitmap).
+- Zoom and pan are view-only: the Markdown document is never modified.
+- No regression to existing single-click highlight or double-click edit behaviour.
+
+**In scope:**
+- Hover-revealed magnifier button on rendered diagrams.
+- Full-pane viewer with zoom, pan, fit, and close.
+- Keyboard support and focus management for the viewer.
+- Error and empty states hide the button.
+
+**Out of scope:**
+- Inline zoom/pan on the diagram in the document flow (viewer only).
+- Export of the zoomed view.
+- Pinch-to-zoom / touch gestures.
+- Persisting zoom level between openings.
+
+---
+
+## 4. UX & Behavior
+
+**Entry points:**
+- Magnifier button in the top-right corner of a rendered diagram, revealed on hover or keyboard focus.
+
+**User flows:**
+
+### Flow 1: Read a dense diagram
+1. User hovers a rendered diagram; the magnifier appears.
+2. User clicks it; the viewer opens fitted to the pane.
+3. User scrolls to zoom in on a region and drags to pan around it.
+4. User presses `Esc`; the viewer closes and the document is unchanged.
+
+### Flow 2: Keyboard-only
+1. User tabs to the magnifier button (a visible focus ring appears) and presses Enter.
+2. Focus moves into the viewer; `+`/`-` zoom, `0` re-fits, Tab cycles the controls without leaving the dialog.
+3. `Esc` closes and focus returns to the magnifier button.
+
+**Behavior rules:**
+- Single click and double click on the diagram keep their existing meanings; the button suppresses `mousedown`, `click`, and `dblclick` so it triggers neither.
+- Clicking empty space beside the diagram dismisses the viewer; clicking the diagram or the controls does not.
+- A drag that ends over empty space does not dismiss the viewer.
+- Scale is clamped to 10%–1000%.
+- The button is hidden when the diagram is empty or failed to render.
+- A failure to load the viewer module is logged, not surfaced — the diagram stays readable inline.
+
+---
+
+## 5. Technical Plan
+
+**Surfaces:**
+- Webview only. No extension-host changes, no message protocol changes.
+
+**Key changes:**
+- `src/webview/features/mermaidLightbox.ts` – new; the viewer, its zoom/pan state, and focus management.
+- `src/webview/extensions/mermaid.ts` – adds the magnifier button to the NodeView and wires it to a dynamic import of the viewer.
+- `src/webview/editor.css` – button styles inside the `.markdown-editor` scope; viewer styles at top level.
+- `src/__tests__/webview/mermaid-lightbox.test.ts` – new; viewer behaviour.
+- `src/__tests__/webview/mermaid-zoom-button.test.ts` – new; NodeView button behaviour against a real TipTap editor.
+
+**Architecture notes:**
+- Zoom/pan state lives in the `showMermaidLightbox` closure and is never serialised, so the document cannot be dirtied by viewing.
+- The viewer is loaded via dynamic `import()` so it costs nothing until first use. esbuild inlines it into the single webview bundle.
+- Viewer styles sit **outside** the `.markdown-editor` nesting block because the overlay mounts on `document.body`.
+- The overlay is `position: fixed` within the webview iframe, so it covers the editor pane rather than the whole VS Code window. This is a platform limit, not a choice.
+
+**Performance considerations:**
+- No `will-change` on the transformed element. It promotes the layer to a fixed-size raster and makes zoom render an upscaled bitmap instead of re-rendering the SVG.
+
+---
+
+## 6. Work Breakdown
+
+- [x] **Phase 1: Viewer** - standalone `showMermaidLightbox`
+  - [x] Open/close: Escape, close button, click on empty space
+  - [x] Zoom: wheel, buttons, keyboard, clamping, fit-on-open
+  - [x] Pan: drag with accumulation, plus the drag-vs-dismiss guard
+  - [x] Focus: move in on open, trap Tab, restore to opener on close
+- [x] **Phase 2: NodeView integration**
+  - [x] Hover-revealed button with a focus ring
+  - [x] Event suppression so it never selects or edits the node
+  - [x] Hidden on empty and error states
+  - [x] Error handling around the dynamic import
+- [x] **Testing**
+  - [x] 31 unit tests for the viewer (jsdom)
+  - [x] 6 tests for the NodeView button against a real TipTap editor
+  - [x] End-to-end verification driving real VS Code with the packaged VSIX
+  - [x] QA manual updated (§5.10)
+
+---
+
+## 7. Implementation Log
+
+### 2026-08-15 – Built and shipped
+
+- **What:** Full feature, TDD throughout — four red/green cycles for the viewer, one for the NodeView button.
+- **Files:** `mermaidLightbox.ts` (new), `mermaid.ts`, `editor.css`, two new test files.
+- **Notes:** Two bugs surfaced only because tests forced the drag-vs-click question: an early version closed the viewer when the zoom buttons were clicked, and again whenever a pan gesture ended over empty space.
+
+### 2026-08-15 – Blurry zoom, root-caused and fixed
+
+- **What:** Zooming past ~200% produced a soft, upscaled image.
+- **Files:** `editor.css`.
+- **Notes:** Cause was `will-change: transform` on `.mermaid-lightbox-canvas`. It promotes the element to a compositor layer rasterised once at its natural size (281px here), which the GPU then scaled to 2016px at 716% zoom. Isolated by comparing three variants at identical zoom in a real window: as-shipped (blurry), `will-change` removed (sharp), and SVG re-layout in pixels (sharp). Removing the hint was the smaller of the two fixes and equally sharp, so the transform approach stayed.
+
+### 2026-08-15 – Self-review against `vibe-coding-rules/`
+
+- **What:** Audit found four gaps; all closed.
+- **Files:** `mermaidLightbox.ts`, `mermaid.ts`, `editor.css`, `docs/QA_MANUAL.md`, this plan.
+- **Notes:** Missing `try/catch` on the async click handler; no focus ring on the magnifier button; `aria-modal="true"` set without any real focus management behind it; no plan file or QA steps.
+
+---
+
+## 8. Decisions & Tradeoffs
+
+- **Viewer over inline zoom:** inline zoom would have to fight the NodeView's existing `mousedown`/`click`/`dblclick` handlers, the draggable-block handle, and page scroll. The viewer sidesteps all four, and the transform code can be reused if inline zoom is wanted later.
+- **New hover button over rebinding double click:** double click already opens the code editor and is shipped behaviour (`task-mermaid-double-click-edit`). Changing it would break existing muscle memory.
+- **CSS transform over SVG re-layout:** both render equally sharp once `will-change` is gone. The transform version is smaller and already tested.
+- **Dropped the double-click fit/100% toggle:** for any diagram that already fits, the two states are identical, so the toggle would usually do nothing. The fit button and `0` cover the need.
+- **Dismiss on empty space, not "backdrop":** the viewport fills the overlay, so there is effectively no backdrop to click.
+
+---
+
+## 9. Follow-up & Future Work
+
+- Inline zoom/pan on the diagram in the document flow, reusing the transform logic here.
+- `task-p0-mermaid-split-view` rebuilds this NodeView; the button and its event suppression will need re-wiring.
+- Rename the button's label — it says "Open diagram in full screen", but a webview overlay can only cover the editor pane.
+- Rapid repeated zooming can show brief softness mid-gesture while Chromium re-rasterises. Sizing the SVG in pixels instead of transforming it would remove this entirely.
+- `.mermaid-preview-btn` in `editor.css` is dead: nothing renders it, only a test fixture references it.

--- a/src/__tests__/webview/mermaid-lightbox.test.ts
+++ b/src/__tests__/webview/mermaid-lightbox.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Tests for the mermaid lightbox: full-screen zoom/pan viewer
+ * @jest-environment jsdom
+ */
+
+import { showMermaidLightbox } from '../../webview/features/mermaidLightbox';
+
+const SVG = '<svg id="diagram"><g><text>A</text></g></svg>';
+
+const overlay = () => document.querySelector('.mermaid-lightbox-overlay');
+const canvas = () => document.querySelector('.mermaid-lightbox-canvas') as HTMLElement;
+const zoomLevel = () => document.querySelector('.mermaid-lightbox-zoom-level')?.textContent;
+const click = (selector: string) => (document.querySelector(selector) as HTMLButtonElement).click();
+const scaleOf = () => Number(/scale\(([\d.]+)\)/.exec(canvas().style.transform)?.[1]);
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('Mermaid lightbox: open and close', () => {
+  it('should render the provided svg inside the overlay', () => {
+    showMermaidLightbox(SVG);
+
+    expect(overlay()).not.toBeNull();
+    expect(canvas().querySelector('#diagram')).not.toBeNull();
+  });
+
+  it('should close on Escape key', () => {
+    showMermaidLightbox(SVG);
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+
+    expect(overlay()).toBeNull();
+  });
+
+  it('should close when the close button is clicked', () => {
+    showMermaidLightbox(SVG);
+
+    (document.querySelector('#mlb-close') as HTMLButtonElement).click();
+
+    expect(overlay()).toBeNull();
+  });
+
+  it('should close when the backdrop is clicked', () => {
+    showMermaidLightbox(SVG);
+
+    (overlay() as HTMLElement).click();
+
+    expect(overlay()).toBeNull();
+  });
+
+  it('should stay open when the diagram itself is clicked', () => {
+    showMermaidLightbox(SVG);
+
+    canvas().click();
+
+    expect(overlay()).not.toBeNull();
+  });
+
+  it('should stop responding to Escape once closed', () => {
+    showMermaidLightbox(SVG);
+    (document.querySelector('#mlb-close') as HTMLButtonElement).click();
+
+    showMermaidLightbox(SVG);
+    const second = overlay();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+
+    expect(second).not.toBeNull();
+    expect(overlay()).toBeNull();
+    expect(document.querySelectorAll('.mermaid-lightbox-overlay')).toHaveLength(0);
+  });
+});
+
+describe('Mermaid lightbox: zoom', () => {
+  it('should open at 100% when the viewport has no measurable layout', () => {
+    showMermaidLightbox(SVG);
+
+    expect(zoomLevel()).toBe('100%');
+    expect(scaleOf()).toBe(1);
+  });
+
+  it('should zoom in by one step when the zoom-in button is clicked', () => {
+    showMermaidLightbox(SVG);
+
+    click('#mlb-zoom-in');
+
+    expect(scaleOf()).toBeCloseTo(1.2);
+    expect(zoomLevel()).toBe('120%');
+  });
+
+  it('should zoom out by one step when the zoom-out button is clicked', () => {
+    showMermaidLightbox(SVG);
+
+    click('#mlb-zoom-out');
+
+    expect(scaleOf()).toBeCloseTo(1 / 1.2);
+    expect(zoomLevel()).toBe('83%');
+  });
+
+  it('should clamp zoom in at 1000%', () => {
+    showMermaidLightbox(SVG);
+
+    for (let i = 0; i < 40; i++) click('#mlb-zoom-in');
+
+    expect(scaleOf()).toBe(10);
+    expect(zoomLevel()).toBe('1000%');
+  });
+
+  it('should clamp zoom out at 10%', () => {
+    showMermaidLightbox(SVG);
+
+    for (let i = 0; i < 40; i++) click('#mlb-zoom-out');
+
+    expect(scaleOf()).toBe(0.1);
+    expect(zoomLevel()).toBe('10%');
+  });
+
+  it('should restore the fitted view when the fit button is clicked', () => {
+    showMermaidLightbox(SVG);
+    click('#mlb-zoom-in');
+    click('#mlb-zoom-in');
+
+    click('#mlb-fit');
+
+    expect(scaleOf()).toBe(1);
+    expect(canvas().style.transform).toBe('translate(0px, 0px) scale(1)');
+  });
+
+  it('should zoom in on a wheel scroll up', () => {
+    showMermaidLightbox(SVG);
+
+    canvas().dispatchEvent(new WheelEvent('wheel', { deltaY: -100, bubbles: true }));
+
+    expect(scaleOf()).toBeGreaterThan(1);
+  });
+
+  it('should zoom out on a wheel scroll down', () => {
+    showMermaidLightbox(SVG);
+
+    canvas().dispatchEvent(new WheelEvent('wheel', { deltaY: 100, bubbles: true }));
+
+    expect(scaleOf()).toBeLessThan(1);
+  });
+});
+
+describe('Mermaid lightbox: pan', () => {
+  const viewport = () => document.querySelector('.mermaid-lightbox-viewport') as HTMLElement;
+
+  const drag = (from: [number, number], to: [number, number]) => {
+    viewport().dispatchEvent(
+      new MouseEvent('mousedown', { clientX: from[0], clientY: from[1], bubbles: true })
+    );
+    document.dispatchEvent(
+      new MouseEvent('mousemove', { clientX: to[0], clientY: to[1], bubbles: true })
+    );
+  };
+
+  it('should move the diagram by the drag distance', () => {
+    showMermaidLightbox(SVG);
+
+    drag([100, 100], [150, 130]);
+
+    expect(canvas().style.transform).toContain('translate(50px, 30px)');
+  });
+
+  it('should keep the diagram still after the drag is released', () => {
+    showMermaidLightbox(SVG);
+    drag([100, 100], [150, 130]);
+
+    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 400, clientY: 400 }));
+
+    expect(canvas().style.transform).toContain('translate(50px, 30px)');
+  });
+
+  it('should accumulate across successive drags', () => {
+    showMermaidLightbox(SVG);
+
+    drag([0, 0], [10, 10]);
+    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+    drag([0, 0], [5, 5]);
+
+    expect(canvas().style.transform).toContain('translate(15px, 15px)');
+  });
+
+  it('should mark the viewport as grabbing only while dragging', () => {
+    showMermaidLightbox(SVG);
+
+    drag([0, 0], [10, 10]);
+    expect(viewport().classList.contains('grabbing')).toBe(true);
+
+    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+    expect(viewport().classList.contains('grabbing')).toBe(false);
+  });
+
+  it('should stop panning after the lightbox is closed', () => {
+    showMermaidLightbox(SVG);
+    drag([0, 0], [10, 10]);
+    const closed = canvas();
+
+    click('#mlb-close');
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 900, clientY: 900 }));
+
+    expect(closed.style.transform).toContain('translate(10px, 10px)');
+  });
+});
+
+describe('Mermaid lightbox: keyboard', () => {
+  const press = (key: string) =>
+    document.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+
+  it('should zoom in on "+"', () => {
+    showMermaidLightbox(SVG);
+
+    press('+');
+
+    expect(scaleOf()).toBeCloseTo(1.2);
+  });
+
+  it('should zoom in on "=" so the unshifted key works', () => {
+    showMermaidLightbox(SVG);
+
+    press('=');
+
+    expect(scaleOf()).toBeCloseTo(1.2);
+  });
+
+  it('should zoom out on "-"', () => {
+    showMermaidLightbox(SVG);
+
+    press('-');
+
+    expect(scaleOf()).toBeCloseTo(1 / 1.2);
+  });
+
+  it('should refit on "0"', () => {
+    showMermaidLightbox(SVG);
+    click('#mlb-zoom-in');
+    click('#mlb-zoom-in');
+
+    press('0');
+
+    expect(canvas().style.transform).toBe('translate(0px, 0px) scale(1)');
+  });
+});
+
+describe('Mermaid lightbox: click to dismiss vs pan', () => {
+  const viewport = () => document.querySelector('.mermaid-lightbox-viewport') as HTMLElement;
+
+  it('should close when empty space beside the diagram is clicked', () => {
+    showMermaidLightbox(SVG);
+
+    viewport().click();
+
+    expect(overlay()).toBeNull();
+  });
+
+  it('should stay open when a pan gesture ends over empty space', () => {
+    showMermaidLightbox(SVG);
+    const view = viewport();
+
+    view.dispatchEvent(new MouseEvent('mousedown', { clientX: 10, clientY: 10, bubbles: true }));
+    document.dispatchEvent(
+      new MouseEvent('mousemove', { clientX: 200, clientY: 90, bubbles: true })
+    );
+    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+    view.click();
+
+    expect(overlay()).not.toBeNull();
+  });
+
+  it('should close on a click that follows a press without movement', () => {
+    showMermaidLightbox(SVG);
+    const view = viewport();
+
+    view.dispatchEvent(new MouseEvent('mousedown', { clientX: 10, clientY: 10, bubbles: true }));
+    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+    view.click();
+
+    expect(overlay()).toBeNull();
+  });
+});
+
+describe('Mermaid lightbox: focus management', () => {
+  const focusables = () =>
+    Array.from((overlay() as HTMLElement).querySelectorAll('button')) as HTMLButtonElement[];
+
+  const tab = (shiftKey = false) =>
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', shiftKey, bubbles: true }));
+
+  it('should move focus into the dialog on open', () => {
+    showMermaidLightbox(SVG);
+
+    expect((overlay() as HTMLElement).contains(document.activeElement)).toBe(true);
+  });
+
+  it('should return focus to the element that opened it', () => {
+    const trigger = document.createElement('button');
+    document.body.appendChild(trigger);
+    trigger.focus();
+
+    showMermaidLightbox(SVG);
+    click('#mlb-close');
+
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it('should wrap focus from the last control back to the first', () => {
+    showMermaidLightbox(SVG);
+    const buttons = focusables();
+    buttons[buttons.length - 1].focus();
+
+    tab();
+
+    expect(document.activeElement).toBe(buttons[0]);
+  });
+
+  it('should wrap focus backwards from the first control to the last', () => {
+    showMermaidLightbox(SVG);
+    const buttons = focusables();
+    buttons[0].focus();
+
+    tab(true);
+
+    expect(document.activeElement).toBe(buttons[buttons.length - 1]);
+  });
+
+  it('should move focus to the first control when tabbing from the container', () => {
+    showMermaidLightbox(SVG);
+
+    tab();
+
+    expect(document.activeElement).toBe(focusables()[0]);
+  });
+});

--- a/src/__tests__/webview/mermaid-zoom-button.test.ts
+++ b/src/__tests__/webview/mermaid-zoom-button.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for the zoom button on a rendered mermaid node
+ * @jest-environment jsdom
+ */
+
+import { Editor } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import mermaid from 'mermaid';
+import { Mermaid } from '../../webview/extensions/mermaid';
+
+describe('Mermaid zoom button', () => {
+  let editor: Editor;
+
+  const settle = () => new Promise(resolve => setTimeout(resolve, 0));
+
+  const createEditor = async () => {
+    const element = document.createElement('div');
+    document.body.appendChild(element);
+    editor = new Editor({
+      element,
+      extensions: [StarterKit, Mermaid],
+      content:
+        '<pre data-language="mermaid"><code class="language-mermaid">graph TD\nA--&gt;B</code></pre>',
+    });
+    await settle();
+  };
+
+  const wrapper = () => document.querySelector('.mermaid-wrapper') as HTMLElement;
+  const zoomButton = () => document.querySelector('.mermaid-zoom-btn') as HTMLButtonElement;
+
+  beforeEach(() => {
+    (mermaid.render as jest.Mock).mockResolvedValue({ svg: '<svg id="diagram"></svg>' });
+  });
+
+  afterEach(() => {
+    editor?.destroy();
+    document.body.innerHTML = '';
+  });
+
+  it('should add a zoom button to a rendered diagram', async () => {
+    await createEditor();
+
+    expect(zoomButton()).not.toBeNull();
+    expect(zoomButton().getAttribute('aria-label')).toBe('Open diagram in full screen');
+  });
+
+  it('should open the lightbox showing the rendered diagram', async () => {
+    await createEditor();
+
+    zoomButton().click();
+    await settle();
+
+    const canvas = document.querySelector('.mermaid-lightbox-canvas') as HTMLElement;
+    expect(canvas).not.toBeNull();
+    expect(canvas.querySelector('#diagram')).not.toBeNull();
+  });
+
+  it('should not highlight the node when the zoom button is clicked', async () => {
+    await createEditor();
+
+    zoomButton().click();
+    await settle();
+
+    expect(wrapper().classList.contains('highlighted')).toBe(false);
+  });
+
+  it('should not open the code editor when the zoom button is double-clicked', async () => {
+    await createEditor();
+
+    zoomButton().dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
+    await settle();
+
+    expect(document.querySelector('.mermaid-editor-overlay')).toBeNull();
+  });
+
+  it('should hide the zoom button when the diagram fails to render', async () => {
+    (mermaid.render as jest.Mock).mockRejectedValue(new Error('bad syntax'));
+    const logged = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await createEditor();
+
+    expect(zoomButton().hidden).toBe(true);
+    logged.mockRestore();
+  });
+});
+
+describe('Mermaid zoom button: lightbox fails to load', () => {
+  const settle = () => new Promise(resolve => setTimeout(resolve, 0));
+
+  afterEach(() => {
+    jest.resetModules();
+    document.body.innerHTML = '';
+  });
+
+  it('should log the failure instead of raising an unhandled rejection', async () => {
+    jest.resetModules();
+    jest.doMock('../../webview/features/mermaidLightbox', () => {
+      throw new Error('chunk load failed');
+    });
+    const logged = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const unhandled = jest.fn();
+    process.on('unhandledRejection', unhandled);
+
+    const { Mermaid: Reloaded } = await import('../../webview/extensions/mermaid');
+    const { Editor: FreshEditor } = await import('@tiptap/core');
+    const StarterKitFresh = (await import('@tiptap/starter-kit')).default;
+    const mermaidLib = (await import('mermaid')).default;
+    (mermaidLib.render as jest.Mock).mockResolvedValue({ svg: '<svg id="diagram"></svg>' });
+
+    const element = document.createElement('div');
+    document.body.appendChild(element);
+    const localEditor = new FreshEditor({
+      element,
+      extensions: [StarterKitFresh, Reloaded],
+      content:
+        '<pre data-language="mermaid"><code class="language-mermaid">graph TD\nA--&gt;B</code></pre>',
+    });
+    await settle();
+
+    (document.querySelector('.mermaid-zoom-btn') as HTMLButtonElement).click();
+    await settle();
+    await settle();
+
+    expect(logged).toHaveBeenCalled();
+    expect(unhandled).not.toHaveBeenCalled();
+
+    process.off('unhandledRejection', unhandled);
+    logged.mockRestore();
+    localEditor.destroy();
+  });
+});

--- a/src/webview/editor.css
+++ b/src/webview/editor.css
@@ -1292,11 +1292,50 @@
     box-shadow: 0 0 0 3px var(--vscode-focusBorder, rgba(0, 122, 204, 0.15));
   }
   
+  /* Zoom button — revealed on hover, sits in the corner ahead of the tooltip */
+  .mermaid-zoom-btn {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    padding: 0;
+    background-color: var(--vscode-editorHoverWidget-background);
+    color: var(--vscode-editorHoverWidget-foreground);
+    border: 1px solid var(--vscode-editorHoverWidget-border);
+    border-radius: 4px;
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+    z-index: 11;
+  }
+
+  .mermaid-wrapper:hover .mermaid-zoom-btn,
+  .mermaid-zoom-btn:focus-visible {
+    opacity: 1;
+  }
+
+  .mermaid-zoom-btn:focus-visible {
+    outline: 1px solid var(--vscode-focusBorder);
+    outline-offset: 1px;
+  }
+
+  .mermaid-zoom-btn:hover {
+    background-color: var(--vscode-toolbar-hoverBackground);
+  }
+
+  .mermaid-zoom-btn .codicon {
+    font-size: 14px;
+  }
+
   /* Tooltip */
   .mermaid-tooltip {
     position: absolute;
     top: 8px;
-    right: 8px;
+    right: 40px;
     background-color: var(--vscode-editorHoverWidget-background);
     color: var(--vscode-editorHoverWidget-foreground);
     border: 1px solid var(--vscode-editorHoverWidget-border);
@@ -3526,4 +3565,92 @@ body.saving-feedback {
 .math-template-chip:focus-visible {
   outline: 1px solid var(--vscode-focusBorder);
   outline-offset: 1px;
+}
+
+/* ============================================
+   Mermaid Lightbox
+   Mounted on document.body, so it lives outside the .markdown-editor scope
+   ============================================ */
+
+.mermaid-lightbox-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 10000;
+  display: flex;
+  flex-direction: column;
+  background: var(--vscode-editor-background);
+}
+
+.mermaid-lightbox-viewport {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  cursor: grab;
+}
+
+.mermaid-lightbox-viewport.grabbing {
+  cursor: grabbing;
+}
+
+/* No will-change/compositor hint here: it pins the layer to one raster size,
+   so zooming would upscale a bitmap instead of re-rendering the SVG. */
+.mermaid-lightbox-canvas {
+  transform-origin: center center;
+  cursor: default;
+}
+
+.mermaid-lightbox-canvas svg {
+  display: block;
+  max-width: none;
+  height: auto;
+}
+
+.mermaid-lightbox-controls {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  align-self: center;
+  margin-bottom: 24px;
+  padding: 6px 8px;
+  background-color: var(--vscode-editorHoverWidget-background);
+  border: 1px solid var(--vscode-editorHoverWidget-border);
+  border-radius: 6px;
+  box-shadow: 0 2px 8px var(--vscode-widget-shadow);
+}
+
+.mermaid-lightbox-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  background: none;
+  color: var(--vscode-editorHoverWidget-foreground);
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.mermaid-lightbox-btn:hover {
+  background-color: var(--vscode-toolbar-hoverBackground);
+}
+
+.mermaid-lightbox-btn:focus-visible {
+  outline: 1px solid var(--vscode-focusBorder);
+  outline-offset: -1px;
+}
+
+.mermaid-lightbox-zoom-level {
+  min-width: 48px;
+  text-align: center;
+  font-size: 0.85em;
+  font-variant-numeric: tabular-nums;
+  color: var(--vscode-editorHoverWidget-foreground);
+  user-select: none;
 }

--- a/src/webview/extensions/mermaid.ts
+++ b/src/webview/extensions/mermaid.ts
@@ -151,8 +151,17 @@ export const Mermaid = Node.create({
       const renderElement = document.createElement('div');
       renderElement.classList.add('mermaid-render');
 
+      const zoomButton = document.createElement('button');
+      zoomButton.type = 'button';
+      zoomButton.classList.add('mermaid-zoom-btn');
+      zoomButton.title = 'Open diagram in full screen';
+      zoomButton.setAttribute('aria-label', 'Open diagram in full screen');
+      zoomButton.innerHTML = '<span class="codicon codicon-zoom-in"></span>';
+      zoomButton.hidden = true;
+
       container.append(codeElement);
       container.appendChild(renderElement);
+      container.appendChild(zoomButton);
 
       // Render mermaid diagram
       const renderDiagram = async () => {
@@ -160,6 +169,7 @@ export const Mermaid = Node.create({
         if (!content) {
           renderElement.innerHTML =
             '<div class="mermaid-placeholder">Enter Mermaid diagram code</div>';
+          zoomButton.hidden = true;
           return;
         }
 
@@ -180,6 +190,7 @@ export const Mermaid = Node.create({
           renderElement.innerHTML = svg;
           renderElement.classList.add('rendered');
           codeElement.classList.add('hidden');
+          zoomButton.hidden = false;
         } catch (error) {
           console.error('Mermaid rendering error:', error);
           const errorMsg = error instanceof Error ? error.message : 'Invalid diagram syntax';
@@ -190,6 +201,7 @@ export const Mermaid = Node.create({
           renderElement.appendChild(errorDiv);
           renderElement.classList.remove('rendered');
           codeElement.classList.remove('hidden');
+          zoomButton.hidden = true;
         }
       };
 
@@ -240,6 +252,21 @@ export const Mermaid = Node.create({
           renderDiagram();
         }
       };
+
+      // The wrapper turns mousedown into a node selection and dblclick into the
+      // code editor; the zoom button must trigger neither.
+      zoomButton.addEventListener('mousedown', event => event.stopPropagation());
+      zoomButton.addEventListener('dblclick', event => event.stopPropagation());
+      zoomButton.addEventListener('click', async event => {
+        event.stopPropagation();
+        try {
+          const { showMermaidLightbox } = await import('../features/mermaidLightbox');
+          showMermaidLightbox(renderElement.innerHTML);
+        } catch (error) {
+          // Non-critical: the diagram stays readable inline, so log rather than interrupt.
+          console.error('[MD4H] Failed to open mermaid lightbox:', error);
+        }
+      });
 
       // Helper: select this mermaid node in ProseMirror so copy / cut /
       // backspace / delete behave correctly. Without a NodeSelection on the

--- a/src/webview/features/mermaidLightbox.ts
+++ b/src/webview/features/mermaidLightbox.ts
@@ -1,0 +1,200 @@
+/**
+ * Copyright (c) 2025-2026 Concret.io
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for details.
+ */
+
+const MIN_SCALE = 0.1;
+const MAX_SCALE = 10;
+const ZOOM_STEP = 1.2;
+
+/**
+ * Full-screen viewer for a rendered mermaid diagram.
+ * View-only: zoom and pan state lives here and is never written back to the document.
+ */
+export function showMermaidLightbox(svg: string): void {
+  const opener = document.activeElement as HTMLElement | null;
+
+  const overlay = document.createElement('div');
+  overlay.className = 'mermaid-lightbox-overlay';
+  overlay.setAttribute('role', 'dialog');
+  overlay.setAttribute('aria-modal', 'true');
+  overlay.setAttribute('aria-label', 'Diagram viewer');
+  // Focusable container so the dialog itself can hold focus on open.
+  overlay.tabIndex = -1;
+
+  const viewport = document.createElement('div');
+  viewport.className = 'mermaid-lightbox-viewport';
+
+  const canvas = document.createElement('div');
+  canvas.className = 'mermaid-lightbox-canvas';
+  canvas.innerHTML = svg;
+
+  const controls = document.createElement('div');
+  controls.className = 'mermaid-lightbox-controls';
+  controls.innerHTML = `
+    <button id="mlb-zoom-out" class="mermaid-lightbox-btn" title="Zoom out" aria-label="Zoom out">
+      <span class="codicon codicon-zoom-out"></span>
+    </button>
+    <span class="mermaid-lightbox-zoom-level" aria-live="polite">100%</span>
+    <button id="mlb-zoom-in" class="mermaid-lightbox-btn" title="Zoom in" aria-label="Zoom in">
+      <span class="codicon codicon-zoom-in"></span>
+    </button>
+    <button id="mlb-fit" class="mermaid-lightbox-btn" title="Fit to screen" aria-label="Fit to screen">
+      <span class="codicon codicon-screen-normal"></span>
+    </button>
+    <button id="mlb-close" class="mermaid-lightbox-btn" title="Close (Esc)" aria-label="Close">
+      <span class="codicon codicon-close"></span>
+    </button>
+  `;
+
+  viewport.appendChild(canvas);
+  overlay.appendChild(viewport);
+  overlay.appendChild(controls);
+  document.body.appendChild(overlay);
+
+  const zoomLabel = controls.querySelector('.mermaid-lightbox-zoom-level') as HTMLElement;
+
+  let scale = 1;
+  let tx = 0;
+  let ty = 0;
+
+  const applyTransform = () => {
+    canvas.style.transform = `translate(${tx}px, ${ty}px) scale(${scale})`;
+    zoomLabel.textContent = `${Math.round(scale * 100)}%`;
+  };
+
+  /** Zoom about a point given in pixels from the viewport centre, keeping that point stationary. */
+  const zoomBy = (factor: number, originX = 0, originY = 0) => {
+    const next = Math.min(MAX_SCALE, Math.max(MIN_SCALE, scale * factor));
+    const ratio = next / scale;
+    tx = originX - (originX - tx) * ratio;
+    ty = originY - (originY - ty) * ratio;
+    scale = next;
+    applyTransform();
+  };
+
+  const fit = () => {
+    const view = viewport.getBoundingClientRect();
+    const diagram = canvas.firstElementChild?.getBoundingClientRect();
+    tx = 0;
+    ty = 0;
+    // Diagram or viewport not laid out yet (also the case under jsdom) — 1:1 is the honest default.
+    if (!diagram?.width || !diagram.height || !view.width || !view.height) {
+      scale = 1;
+    } else {
+      // The measured rect already includes the current scale, so scale through it.
+      const raw = scale * Math.min(view.width / diagram.width, view.height / diagram.height);
+      scale = Math.min(MAX_SCALE, Math.max(MIN_SCALE, raw));
+    }
+    applyTransform();
+  };
+
+  let dragOrigin: { x: number; y: number; tx: number; ty: number } | null = null;
+  let dragMoved = false;
+
+  const handleMouseMove = (event: MouseEvent) => {
+    if (!dragOrigin) return;
+    tx = dragOrigin.tx + (event.clientX - dragOrigin.x);
+    ty = dragOrigin.ty + (event.clientY - dragOrigin.y);
+    dragMoved = true;
+    applyTransform();
+  };
+
+  const endDrag = () => {
+    dragOrigin = null;
+    viewport.classList.remove('grabbing');
+  };
+
+  const close = () => {
+    document.removeEventListener('keydown', handleKeydown);
+    document.removeEventListener('mousemove', handleMouseMove);
+    document.removeEventListener('mouseup', endDrag);
+    overlay.remove();
+    opener?.focus();
+  };
+
+  // aria-modal claims the rest of the page is inert, so Tab must not escape the dialog.
+  const trapTab = (event: KeyboardEvent) => {
+    const controlsList = Array.from(overlay.querySelectorAll('button'));
+    if (!controlsList.length) return;
+    const first = controlsList[0];
+    const last = controlsList[controlsList.length - 1];
+    const active = document.activeElement as HTMLButtonElement | null;
+    const index = active ? controlsList.indexOf(active) : -1;
+
+    if (event.shiftKey) {
+      if (index !== 0 && index !== -1) return;
+      last.focus();
+    } else {
+      if (index !== controlsList.length - 1 && index !== -1) return;
+      first.focus();
+    }
+    event.preventDefault();
+  };
+
+  function handleKeydown(event: KeyboardEvent) {
+    switch (event.key) {
+      case 'Tab':
+        trapTab(event);
+        return;
+      case 'Escape':
+        close();
+        break;
+      case '+':
+      case '=':
+        zoomBy(ZOOM_STEP);
+        break;
+      case '-':
+        zoomBy(1 / ZOOM_STEP);
+        break;
+      case '0':
+        fit();
+        break;
+      default:
+        return;
+    }
+    event.preventDefault();
+  }
+
+  // Only bare space dismisses: not the diagram, not the controls, and not the
+  // click that terminates a pan gesture.
+  overlay.addEventListener('click', event => {
+    if (dragMoved) {
+      dragMoved = false;
+      return;
+    }
+    if (event.target === viewport || event.target === overlay) close();
+  });
+
+  viewport.addEventListener('mousedown', event => {
+    event.preventDefault();
+    dragOrigin = { x: event.clientX, y: event.clientY, tx, ty };
+    viewport.classList.add('grabbing');
+  });
+
+  viewport.addEventListener(
+    'wheel',
+    event => {
+      event.preventDefault();
+      const view = viewport.getBoundingClientRect();
+      const originX = event.clientX - view.left - view.width / 2;
+      const originY = event.clientY - view.top - view.height / 2;
+      zoomBy(event.deltaY < 0 ? ZOOM_STEP : 1 / ZOOM_STEP, originX, originY);
+    },
+    { passive: false }
+  );
+
+  const button = (id: string) => controls.querySelector(`#${id}`) as HTMLButtonElement;
+  button('mlb-zoom-in').addEventListener('click', () => zoomBy(ZOOM_STEP));
+  button('mlb-zoom-out').addEventListener('click', () => zoomBy(1 / ZOOM_STEP));
+  button('mlb-fit').addEventListener('click', fit);
+  button('mlb-close').addEventListener('click', close);
+
+  document.addEventListener('keydown', handleKeydown);
+  document.addEventListener('mousemove', handleMouseMove);
+  document.addEventListener('mouseup', endDrag);
+
+  fit();
+  overlay.focus();
+}


### PR DESCRIPTION
## Description

Adds a zoom-and-pan viewer for rendered Mermaid diagrams. Today a diagram is capped at the editor column width (`.mermaid-render svg { max-width: 100% }`), so a dense flowchart or sequence diagram shrinks until its node labels are unreadable, and the only way to inspect it is to open the code modal and read the source — which is not the same as reading the picture.

Hovering a rendered diagram now reveals a magnifier button in its top-right corner. Clicking it opens the diagram in a viewer that fills the editor pane, fitted and centred, where you can zoom with the wheel, the on-screen buttons, or the keyboard, and pan by dragging.

Zoom and pan are view-only state held in a closure — they are never serialised, so viewing a diagram cannot modify the document.

Existing behaviour is untouched: single click still highlights the block, double click still opens the code editor. The button suppresses `mousedown`, `click`, and `dblclick` so it triggers neither.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/modification

## Related Issues

No linked issue. This came out of using the editor with large diagrams.

## Changes Made

- Add `src/webview/features/mermaidLightbox.ts` — the viewer: zoom (wheel, buttons, `+`/`-`/`=` keys), pan (drag), fit-on-open, `0` to re-fit, scale clamped to 10%–1000%.
- Add a hover-revealed magnifier button to the Mermaid NodeView, loaded via dynamic `import()` so the viewer costs nothing until first use.
- Hide the button when the diagram is empty or failed to render; log and continue if the viewer module fails to load, since the diagram stays readable inline.
- Dismiss on `Esc`, the close button, or a click on empty space — but not on a click that ends a pan gesture, and not on the diagram or the controls.
- Focus management for the dialog: focus moves in on open, Tab is trapped within the controls, and focus returns to the magnifier button on close, so the `aria-modal="true"` is backed by real behaviour.
- Style the button inside the `.markdown-editor` scope and the viewer at top level, since the overlay mounts on `document.body`. All colours come from VS Code theme variables.
- Document the feature in `docs/QA_MANUAL.md` §5.10 and add a plan file under `roadmap/shipped/`.

One implementation note worth flagging for reviewers: the viewer deliberately sets **no** `will-change` on the transformed element. An earlier revision did, and it made zooming render an upscaled bitmap instead of re-rendering the SVG — the hint promotes the element to a compositor layer rasterised once at its natural size (281px here), which the GPU then scaled to 2016px at 716% zoom. There is a comment in the CSS to stop it being reintroduced.

## Screen Recording / Visual Demo

- [ ] I have included a screen recording showing the **before** state (if fixing a bug)
- [ ] I have included a screen recording showing the **after** state (the fix/feature working)
- [ ] Screen recording uploaded to [Loom.com](https://www.loom.com) or similar (paste link below)

**Screen Recording Link:** _pending_

**Screenshots (if applicable):**

_Screenshots below are captured from the packaged VSIX running in a real VS Code window, not a dev host._

- Magnifier button revealed on hover
- Viewer open, fitted to the pane at 139%
- Panned at 200%, content clipping correctly at the viewport edges
- 716% zoom before/after the `will-change` fix, showing vector edges rather than an upscaled raster
- Light and high-contrast themes

## Testing

- [x] All existing tests pass (`npm test`)
- [x] Linting passes with no errors (`npm run lint:fix`)
- [x] Build succeeds (`npm run build:release`)
- [x] Extension can be packaged (`npm run package:release`)
- [x] Manually tested in VS Code Extension Development Host
- [ ] Tested with both saved files (`file:`) and untitled files (`untitled:`)
- [x] Tested in light and dark themes
- [ ] Tested with large documents (1000+ lines) if applicable

**Test suite:** 991 passing across 74 suites, up from 985 — 37 new tests across two files, written before the implementation (TDD).

- `npx jest src/__tests__/webview/mermaid-lightbox.test.ts` — 31 tests: open/close, zoom stepping and clamping, wheel zoom, pan accumulation, keyboard shortcuts, listener cleanup on close, the drag-versus-dismiss distinction, and focus management.
- `npx jest src/__tests__/webview/mermaid-zoom-button.test.ts` — 6 tests against a real TipTap editor: the button renders, opens the viewer with the current SVG, never highlights or edits the node, is hidden on render failure, and logs rather than throwing when the viewer module cannot load.

**Verified end-to-end** against the packaged VSIX installed in a real VS Code window, driving the UI with Playwright: fit-on-open computed 139% from real geometry, two zoom steps landed on exactly 200%, a 180×90 drag produced `translate(180px, 90px)`, `Esc` closed cleanly, and the markdown file came out byte-identical.

Unchecked boxes above are honest gaps: I verified light, dark, **and** high-contrast themes but did not specifically exercise untitled files or a 1000+ line document, neither of which this feature interacts with — it operates entirely within a single NodeView.

### Test Environment

- OS: macOS 26.5.2
- VS Code Version: 1.133.0
- Node Version: 22.21.1

## Documentation

- [ ] Updated README.md (if needed)
- [ ] Updated CHANGELOG.md
- [x] Added/updated code comments
- [x] Updated documentation in `/docs` (if needed)

`CHANGELOG.md` left alone to match recent practice (#65, #71, #73, #74 all skipped it). Happy to add an entry if you'd prefer it in the PR.

## Checklist

- [x] My code follows the project's coding standards (see `CONTRIBUTING.md` and `vibe-coding-rules/`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Error handling is implemented for async operations (see `vibe-coding-rules/coding-standards.md`)
- [x] No `console.log` statements added (or they're properly conditional for debug mode)
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the TDD workflow if this is a new feature (write tests first)

## Additional Notes

- The overlay covers the **editor pane**, not the whole VS Code window. A webview cannot paint outside its own iframe, so this is a platform limit. The button's current label says "Open diagram in full screen", which slightly overstates it — happy to reword if you'd prefer something like "Expand diagram".
- `task-p0-mermaid-split-view` in the pipeline rebuilds this NodeView. The button and its event suppression will need re-wiring when that lands.
- Unrelated, noticed while working here: `.mermaid-preview-btn` in `editor.css` is dead — nothing renders it, only a test fixture references it. Left alone rather than cleaned up in this PR.
