### PR TITLE
fix(lint): reformat union types for current prettier

### DIFF
--- a/src/__tests__/editor/imageReferences.test.ts
+++ b/src/__tests__/editor/imageReferences.test.ts
@@ -32,10 +32,7 @@ jest.mock('vscode', () => ({
   },
   TreeItem: class TreeItem {
     public iconPath:
-      | vscode.Uri
-      | { light: vscode.Uri; dark: vscode.Uri }
-      | vscode.ThemeIcon
-      | undefined;
+      vscode.Uri | { light: vscode.Uri; dark: vscode.Uri } | vscode.ThemeIcon | undefined;
     public description?: string;
     public command?: vscode.Command;
     public contextValue?: string;

--- a/src/__tests__/editor/inMemoryFiles.test.ts
+++ b/src/__tests__/editor/inMemoryFiles.test.ts
@@ -67,10 +67,7 @@ jest.mock('vscode', () => ({
   },
   TreeItem: class TreeItem {
     public iconPath:
-      | vscode.Uri
-      | { light: vscode.Uri; dark: vscode.Uri }
-      | vscode.ThemeIcon
-      | undefined;
+      vscode.Uri | { light: vscode.Uri; dark: vscode.Uri } | vscode.ThemeIcon | undefined;
     public description?: string;
     public command?: vscode.Command;
     public contextValue?: string;

--- a/src/__tests__/webview/draggableBlocks.test.ts
+++ b/src/__tests__/webview/draggableBlocks.test.ts
@@ -268,8 +268,7 @@ describe('DraggableBlocks Extension', () => {
       const ext = editor.extensionManager.extensions.find(e => e.name === 'draggableBlocks');
       expect(ext).toBeDefined();
       const addKeyboardShortcuts = ext?.config.addKeyboardShortcuts as
-        | ((this: { editor: Editor }) => Record<string, unknown>)
-        | undefined;
+        ((this: { editor: Editor }) => Record<string, unknown>) | undefined;
       expect(addKeyboardShortcuts).toBeDefined();
       const shortcuts = addKeyboardShortcuts?.call({ editor });
       expect(shortcuts).toBeDefined();

--- a/src/webview/features/imageRenameDialog.ts
+++ b/src/webview/features/imageRenameDialog.ts
@@ -485,8 +485,7 @@ export function showImageRenameDialog(img: HTMLImageElement, vscodeApi: VsCodeAp
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const getImageReferences = (window as any).getImageReferences as
-    | ((path: string) => Promise<unknown>)
-    | undefined;
+    ((path: string) => Promise<unknown>) | undefined;
 
   if (typeof getImageReferences === 'function' && imagePath) {
     getImageReferences(imagePath)
@@ -581,8 +580,7 @@ export function showImageRenameDialog(img: HTMLImageElement, vscodeApi: VsCodeAp
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const checkImageRename = (window as any).checkImageRename as
-      | ((oldPath: string, newName: string) => Promise<unknown>)
-      | undefined;
+      ((oldPath: string, newName: string) => Promise<unknown>) | undefined;
     if (typeof checkImageRename === 'function') {
       renameBtn.disabled = true;
       renameBtn.style.opacity = '0.7';

--- a/src/webview/features/imageResizeModal.ts
+++ b/src/webview/features/imageResizeModal.ts
@@ -233,8 +233,7 @@ export async function showImageResizeModal(
     const callbacks: Map<string, (result: WorkspaceCheckResult) => void> =
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ((window as any)._workspaceCheckCallbacks as
-        | Map<string, (result: WorkspaceCheckResult) => void>
-        | undefined) ?? new Map();
+        Map<string, (result: WorkspaceCheckResult) => void> | undefined) ?? new Map();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (window as any)._workspaceCheckCallbacks = callbacks;
 
@@ -808,8 +807,7 @@ function showResizeModalForLocalImage(
     absolutePath || img.getAttribute('data-markdown-src') || img.getAttribute('src') || '';
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const getImageReferences = (window as any).getImageReferences as
-    | ((path: string) => Promise<unknown>)
-    | undefined;
+    ((path: string) => Promise<unknown>) | undefined;
 
   if (typeof getImageReferences === 'function' && imagePathForReferences) {
     getImageReferences(imagePathForReferences)


### PR DESCRIPTION
## Description

CI has been failing on `main` since the v0.3.0 release commits on 7 Aug. The last green run was #76 on 3 Aug; both release runs and every PR opened since inherit the same failure.

The cause is prettier version drift, not a code change. Prettier now collapses short multi-line union types onto one line and drops the optional leading `|`, so five files formatted under the older style fail `eslint src --ext ts --max-warnings 0`:

```
✖ 7 problems (7 errors, 0 warnings)
  prettier/prettier — Replace `| vscode.Uri ⏎ | { light: ... } ⏎ | vscode.ThemeIcon` with `vscode.Uri | { light: ... } | vscode.ThemeIcon`
```

This applies `npm run lint:fix` and nothing else.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test addition/modification

## Related Issues

No linked issue. Found while opening #78, which shows the identical seven errors purely by inheriting them from `main`.

## Changes Made

- `src/__tests__/editor/imageReferences.test.ts`
- `src/__tests__/editor/inMemoryFiles.test.ts`
- `src/__tests__/webview/draggableBlocks.test.ts`
- `src/webview/features/imageRenameDialog.ts`
- `src/webview/features/imageResizeModal.ts`

The only textual change in all five is the removal of the redundant leading `|` on multi-line union types, which is optional TypeScript syntax. Verified by stripping whitespace and pipes from each file before and after — the remaining characters are identical, so nothing else moved.

## Screen Recording / Visual Demo

Not applicable; this is a formatting fix with no user-visible behaviour.

## Testing

- [x] All existing tests pass (`npm test`) — 954 passing, 72 suites
- [x] Linting passes with no errors (`npm run lint`) — clean, was 7 errors
- [x] Build succeeds (`npm run build:release`)
- [x] Extension can be packaged (`npm run package:release`)
- [ ] Manually tested in VS Code Extension Development Host
- [ ] Tested with both saved files (`file:`) and untitled files (`untitled:`)
- [ ] Tested in light and dark themes
- [ ] Tested with large documents (1000+ lines) if applicable

Manual testing boxes left unchecked deliberately: this change cannot affect runtime behaviour, so there is nothing to exercise by hand.

### Test Environment

- OS: macOS 26.5.2
- VS Code Version: 1.133.0
- Node Version: 22.21.1

## Documentation

- [ ] Updated README.md (if needed)
- [ ] Updated CHANGELOG.md
- [ ] Added/updated code comments
- [ ] Updated documentation in `/docs` (if needed)

No documentation impact.

## Checklist

- [x] My code follows the project's coding standards (see `CONTRIBUTING.md` and `vibe-coding-rules/`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Error handling is implemented for async operations (see `vibe-coding-rules/coding-standards.md`)
- [x] No `console.log` statements added (or they're properly conditional for debug mode)
- [x] Any dependent changes have been merged and published
- [ ] I have read and followed the TDD workflow if this is a new feature (write tests first)

No new tests: the check that proves this fix is `npm run lint` itself, which is already in CI.

## Additional Notes

Worth considering separately: `prettier` is pinned with a caret range, so a patch release of the formatter can turn `main` red without anyone changing code. Pinning it exactly would stop this recurring. Happy to open that as its own PR if you'd like it.
