### PR TITLE
style: normalize existing lint formatting

### DIFF
--- a/src/__tests__/editor/imageReferences.test.ts
+++ b/src/__tests__/editor/imageReferences.test.ts
@@ -32,10 +32,7 @@ jest.mock('vscode', () => ({
   },
   TreeItem: class TreeItem {
     public iconPath:
-      | vscode.Uri
-      | { light: vscode.Uri; dark: vscode.Uri }
-      | vscode.ThemeIcon
-      | undefined;
+      vscode.Uri | { light: vscode.Uri; dark: vscode.Uri } | vscode.ThemeIcon | undefined;
     public description?: string;
     public command?: vscode.Command;
     public contextValue?: string;

--- a/src/__tests__/editor/inMemoryFiles.test.ts
+++ b/src/__tests__/editor/inMemoryFiles.test.ts
@@ -67,10 +67,7 @@ jest.mock('vscode', () => ({
   },
   TreeItem: class TreeItem {
     public iconPath:
-      | vscode.Uri
-      | { light: vscode.Uri; dark: vscode.Uri }
-      | vscode.ThemeIcon
-      | undefined;
+      vscode.Uri | { light: vscode.Uri; dark: vscode.Uri } | vscode.ThemeIcon | undefined;
     public description?: string;
     public command?: vscode.Command;
     public contextValue?: string;

--- a/src/__tests__/webview/draggableBlocks.test.ts
+++ b/src/__tests__/webview/draggableBlocks.test.ts
@@ -268,8 +268,7 @@ describe('DraggableBlocks Extension', () => {
       const ext = editor.extensionManager.extensions.find(e => e.name === 'draggableBlocks');
       expect(ext).toBeDefined();
       const addKeyboardShortcuts = ext?.config.addKeyboardShortcuts as
-        | ((this: { editor: Editor }) => Record<string, unknown>)
-        | undefined;
+        ((this: { editor: Editor }) => Record<string, unknown>) | undefined;
       expect(addKeyboardShortcuts).toBeDefined();
       const shortcuts = addKeyboardShortcuts?.call({ editor });
       expect(shortcuts).toBeDefined();

--- a/src/webview/features/imageRenameDialog.ts
+++ b/src/webview/features/imageRenameDialog.ts
@@ -485,8 +485,7 @@ export function showImageRenameDialog(img: HTMLImageElement, vscodeApi: VsCodeAp
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const getImageReferences = (window as any).getImageReferences as
-    | ((path: string) => Promise<unknown>)
-    | undefined;
+    ((path: string) => Promise<unknown>) | undefined;
 
   if (typeof getImageReferences === 'function' && imagePath) {
     getImageReferences(imagePath)
@@ -581,8 +580,7 @@ export function showImageRenameDialog(img: HTMLImageElement, vscodeApi: VsCodeAp
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const checkImageRename = (window as any).checkImageRename as
-      | ((oldPath: string, newName: string) => Promise<unknown>)
-      | undefined;
+      ((oldPath: string, newName: string) => Promise<unknown>) | undefined;
     if (typeof checkImageRename === 'function') {
       renameBtn.disabled = true;
       renameBtn.style.opacity = '0.7';

--- a/src/webview/features/imageResizeModal.ts
+++ b/src/webview/features/imageResizeModal.ts
@@ -233,8 +233,7 @@ export async function showImageResizeModal(
     const callbacks: Map<string, (result: WorkspaceCheckResult) => void> =
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ((window as any)._workspaceCheckCallbacks as
-        | Map<string, (result: WorkspaceCheckResult) => void>
-        | undefined) ?? new Map();
+        Map<string, (result: WorkspaceCheckResult) => void> | undefined) ?? new Map();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (window as any)._workspaceCheckCallbacks = callbacks;
 
@@ -808,8 +807,7 @@ function showResizeModalForLocalImage(
     absolutePath || img.getAttribute('data-markdown-src') || img.getAttribute('src') || '';
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const getImageReferences = (window as any).getImageReferences as
-    | ((path: string) => Promise<unknown>)
-    | undefined;
+    ((path: string) => Promise<unknown>) | undefined;
 
   if (typeof getImageReferences === 'function' && imagePathForReferences) {
     getImageReferences(imagePathForReferences)


### PR DESCRIPTION
## Summary

- normalize five TypeScript declarations to the repository Prettier configuration
- remove the seven baseline lint errors currently present on `main`
- unblock required CI checks for PRs based on the 0.3.0 release

## Root cause

Commit `21ac3ec` reformatted five declarations into a multiline union style rejected by the current `prettier/prettier` ESLint rule. The latest `main` CI run and PR #82 both fail before Jest reaches the test step.

This PR contains formatting-only changes and is intentionally separate from PR #82.

## Verification

- `npm run lint`: passed
- `npm run test:coverage`: 72 suites passed, 954 tests passed
- `npm run build:release`: passed
- `git diff --check origin/main...HEAD`: passed