### PR TITLE
fix: prevent toolbar icon from swallowing pointer events

### DIFF
--- a/src/webview/editor.css
+++ b/src/webview/editor.css
@@ -1651,6 +1651,10 @@
     opacity: 0.75;
   }
   
+  .toolbar-button > .toolbar-icon {
+    pointer-events: none;
+  }
+  
   .toolbar-button:hover {
     background-color: var(--md-hover-bg);
     opacity: 1;


### PR DESCRIPTION
## Summary

Fixes toolbar button tooltips not showing reliably. The child SVG icon inside each `.toolbar-button` was capturing pointer events, so hover (tooltip) landed on the icon rather than the button. Adding `pointer-events: none` to `.toolbar-icon` lets hover pass through to the button.

## Change

- `src/webview/editor.css`: `.toolbar-button > .toolbar-icon { pointer-events: none; }`

## Testing

End-user testing in VS Code (Extension Development Host) — this CSS change is not automatically testable. Confirmed toolbar tooltips now appear on hover as shown in the recordings below.

## Screen recordings

- **Before:** https://www.loom.com/share/7ada1d09666c4d2b99c7b468ada66557
- **After:** https://www.loom.com/share/03a0dd6248304a4b8c788ccbc73edc04
